### PR TITLE
pmpcfg illegal values issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ SAIL_SYS_SRCS += riscv_csr_ext.sail         # access to CSR extensions
 SAIL_SYS_SRCS += riscv_sys_control.sail     # general exception handling
 
 SAIL_RV32_VM_SRCS = riscv_vmem_sv32.sail riscv_vmem_rv32.sail
-SAIL_RV64_VM_SRCS = riscv_vmem_sv39.sail riscv_vmem_sv48.sail riscv_vmem_rv64.sail
+SAIL_RV64_VM_SRCS = riscv_vmem_sv39.sail riscv_vmem_sv48.sail riscv_vmem_sv57.sail riscv_vmem_rv64.sail
 
 SAIL_VM_SRCS = riscv_pte.sail riscv_ptw.sail riscv_vmem_common.sail riscv_vmem_tlb.sail
 ifeq ($(ARCH),RV32)

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -100,7 +100,7 @@ val pmpCheckRWX: (Pmpcfg_ent, AccessType(ext_access_type)) -> bool
 function pmpCheckRWX(ent, acc) = {
   match acc {
     Read(_)      => ent.R() == 0b1,
-    Write(_)     => ent.W() == 0b1,
+    Write(_)     => ent.W() == 0b1 & ent.R() != 0b0,
     ReadWrite(_) => ent.R() == 0b1 & ent.W() == 0b1,
     Execute()    => ent.X() == 0b1
   }

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -364,7 +364,7 @@ function extStatus_of_bits(e) =
 /* supervisor-level address translation modes */
 
 type satp_mode = bits(4)
-enum SATPMode = {Sbare, Sv32, Sv39, Sv48}
+enum SATPMode = {Sbare, Sv32, Sv39, Sv48, Sv57}
 
 function satp64Mode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
   match (a, m) {
@@ -372,6 +372,7 @@ function satp64Mode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode)
     (RV32, 0x1) => Some(Sv32),
     (RV64, 0x8) => Some(Sv39),
     (RV64, 0x9) => Some(Sv48),
+    (RV64, 0xA) => Some(Sv57),
     (_, _)      => None()
   }
 

--- a/model/riscv_vmem_common.sail
+++ b/model/riscv_vmem_common.sail
@@ -209,6 +209,33 @@ bitfield SV48_PTE : pte48 = {
   BITS  : 7  .. 0
 }
 
+/* Sv57 parameters and bitfield layouts */
+
+let SV57_LEVEL_BITS = 9
+let SV57_LEVELS     = 5
+let PTE57_LOG_SIZE  = 3
+let PTE57_SIZE      = 8
+
+type vaddr57 = bits(57)
+type pte57   = bits(64)
+
+bitfield SV57_Vaddr : vaddr57 = {
+  VPNi  : 56 .. 12,
+  PgOfs : 11 .. 0
+}
+
+bitfield SV57_Paddr : paddr64 = {
+  PPNi  : 55 .. 12,
+  PgOfs : 11 .. 0
+}
+
+bitfield SV57_PTE : pte57 = {
+  Ext   : 63 .. 54,
+  PPNi  : 53 .. 10,
+  RSW   : 9  .. 8,
+  BITS  : 7  .. 0
+}
+
 /* The types below are parameterized by 'paddr and 'pte to support
  * various architectural widths (e.g. RV32, RV64).  ext_ptw supports
  * extensions to the default address translation and page-table-walk.

--- a/model/riscv_vmem_rv64.sail
+++ b/model/riscv_vmem_rv64.sail
@@ -91,6 +91,12 @@ function isValidSv48Addr(vAddr : xlenbits) -> bool = {
                       else zeros())
 }
 
+function isValidSv57Addr(vAddr : xlenbits) -> bool = {
+  vAddr[63 .. 57] == (if   vAddr[56] == bitone
+                      then ones()
+                      else zeros())
+}
+
 /* Compute the address translation mode. */
 
 val translationMode : (Privilege) -> SATPMode
@@ -145,6 +151,13 @@ function translateAddr_priv(vAddr, ac, effPriv) = {
                     }
                else TR_Failure(translationException(ac, PTW_Invalid_Addr()), ext_ptw)
              },
+    Sv57  => { if   isValidSv57Addr(vAddr)
+               then match translate57(asid, ptb, vAddr[56 .. 0], ac, effPriv, mxr, do_sum, SV57_LEVELS - 1, ext_ptw) {
+                      TR_Address(pa, ext_ptw) => TR_Address(zero_extend(pa), ext_ptw),
+                      TR_Failure(f, ext_ptw)  => TR_Failure(translationException(ac, f), ext_ptw)
+                    }
+               else TR_Failure(translationException(ac, PTW_Invalid_Addr()), ext_ptw)
+             },
     _     => internal_error(__FILE__, __LINE__, "unsupported address translation scheme")
   }
 }
@@ -156,10 +169,10 @@ function translateAddr(vAddr, ac) =
 val flush_TLB : (option(xlenbits), option(xlenbits)) -> unit
 function flush_TLB(asid_xlen, addr_xlen) -> unit = {
   /* Flush both Sv39 and Sv48 TLBs. */
-  let (addr39, addr48) : (option(vaddr39), option(vaddr48)) =
+  let (addr39, addr48, addr57) : (option(vaddr39), option(vaddr48), option(vaddr57)) =
     match addr_xlen {
-      None()  => (None(), None()),
-      Some(a) => (Some(a[38 .. 0]), Some(a[47 .. 0]))
+      None()  => (None(), None(), None()),
+      Some(a) => (Some(a[38 .. 0]), Some(a[47 .. 0]), Some(a[56 .. 0]))
     };
   let asid : option(asid64) =
     match asid_xlen {
@@ -167,10 +180,12 @@ function flush_TLB(asid_xlen, addr_xlen) -> unit = {
       Some(a) => Some(a[15 .. 0])
   };
   flush_TLB39(asid, addr39);
-  flush_TLB48(asid, addr48)
+  flush_TLB48(asid, addr48);
+  flush_TLB57(asid, addr57)
 }
 
 function init_vmem() -> unit = {
   init_vmem_sv39();
-  init_vmem_sv48()
+  init_vmem_sv48();
+  init_vmem_sv57()
 }

--- a/model/riscv_vmem_sv57.sail
+++ b/model/riscv_vmem_sv57.sail
@@ -1,0 +1,254 @@
+/*=======================================================================================*/
+/*  RISCV Sail Model                                                                     */
+/*                                                                                       */
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except for the snapshots of the Lem and Sail libraries                   */
+/*  in the prover_snapshots directory (which include copies of their                     */
+/*  licences), is subject to the BSD two-clause licence below.                           */
+/*                                                                                       */
+/*  Copyright (c) 2017-2021                                                              */
+/*    Prashanth Mundkur                                                                  */
+/*    Rishiyur S. Nikhil and Bluespec, Inc.                                              */
+/*    Jon French                                                                         */
+/*    Brian Campbell                                                                     */
+/*    Robert Norton-Wright                                                               */
+/*    Alasdair Armstrong                                                                 */
+/*    Thomas Bauereiss                                                                   */
+/*    Shaked Flur                                                                        */
+/*    Christopher Pulte                                                                  */
+/*    Peter Sewell                                                                       */
+/*    Alexander Richardson                                                               */
+/*    Hesham Almatary                                                                    */
+/*    Jessica Clarke                                                                     */
+/*    Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo  */
+/*    Peter Rugg                                                                         */
+/*    Aril Computer Corp., for contributions by Scott Johnson                            */
+/*                                                                                       */
+/*  All rights reserved.                                                                 */
+/*                                                                                       */
+/*  This software was developed by the above within the Rigorous                         */
+/*  Engineering of Mainstream Systems (REMS) project, partly funded by                   */
+/*  EPSRC grant EP/K008528/1, at the Universities of Cambridge and                       */
+/*  Edinburgh.                                                                           */
+/*                                                                                       */
+/*  This software was developed by SRI International and the University of               */
+/*  Cambridge Computer Laboratory (Department of Computer Science and                    */
+/*  Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and                 */
+/*  under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA                 */
+/*  SSITH research programme.                                                            */
+/*                                                                                       */
+/*  This project has received funding from the European Research Council                 */
+/*  (ERC) under the European Union’s Horizon 2020 research and innovation                */
+/*  programme (grant agreement 789108, ELVER).                                           */
+/*                                                                                       */
+/*                                                                                       */
+/*  Redistribution and use in source and binary forms, with or without                   */
+/*  modification, are permitted provided that the following conditions                   */
+/*  are met:                                                                             */
+/*  1. Redistributions of source code must retain the above copyright                    */
+/*     notice, this list of conditions and the following disclaimer.                     */
+/*  2. Redistributions in binary form must reproduce the above copyright                 */
+/*     notice, this list of conditions and the following disclaimer in                   */
+/*     the documentation and/or other materials provided with the                        */
+/*     distribution.                                                                     */
+/*                                                                                       */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''                   */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED                    */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                      */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR                  */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                         */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                     */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                     */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                  */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                   */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT                   */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF                   */
+/*  SUCH DAMAGE.                                                                         */
+/*=======================================================================================*/
+
+/* Sv57 address translation for RV64. */
+
+val walk57 : (vaddr57, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV57_PTE) effect {rmem, rmemt, rreg, escape}
+function walk57(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
+  let va = Mk_SV57_Vaddr(vaddr);
+  let pt_ofs : paddr64 = shiftl(zero_extend(shiftr(va.VPNi(), (level * SV57_LEVEL_BITS))[(SV57_LEVEL_BITS - 1) .. 0]),
+                                PTE57_LOG_SIZE);
+  let pte_addr = ptb + pt_ofs;
+  match (mem_read_priv(Read(Data), Supervisor, zero_extend(pte_addr), 8, false, false, false)) {
+    MemException(_) => {
+/*    print("walk57(vaddr=" ^ BitStr(vaddr) ^ " level=" ^ string_of_int(level)
+            ^ " pt_base=" ^ BitStr(ptb)
+            ^ " pt_ofs=" ^ BitStr(pt_ofs)
+            ^ " pte_addr=" ^ BitStr(pte_addr)
+            ^ ": invalid pte address"); */
+      PTW_Failure(PTW_Access(), ext_ptw)
+    },
+    MemValue(v) => {
+      let pte = Mk_SV57_PTE(v);
+      let pbits = pte.BITS();
+      let ext_pte = pte.Ext();
+      let pattr = Mk_PTE_Bits(pbits);
+      let is_global = global | (pattr.G() == 0b1);
+/*    print("walk57(vaddr=" ^ BitStr(vaddr) ^ " level=" ^ string_of_int(level)
+            ^ " pt_base=" ^ BitStr(ptb)
+            ^ " pt_ofs=" ^ BitStr(pt_ofs)
+            ^ " pte_addr=" ^ BitStr(pte_addr)
+            ^ " pte=" ^ BitStr(v)); */
+      if isInvalidPTE(pbits, ext_pte) then {
+/*      print("walk57: invalid pte"); */
+        PTW_Failure(PTW_Invalid_PTE(), ext_ptw)
+      } else {
+        if isPTEPtr(pbits, ext_pte) then {
+          if level > 0 then {
+            /* walk down the pointer to the next level */
+            walk57(vaddr, ac, priv, mxr, do_sum, shiftl(zero_extend(pte.PPNi()), PAGESIZE_BITS), level - 1, is_global, ext_ptw)
+          } else {
+            /* last-level PTE contains a pointer instead of a leaf */
+/*          print("walk57: last-level pte contains a ptr"); */
+            PTW_Failure(PTW_Invalid_PTE(), ext_ptw)
+          }
+        } else { /* leaf PTE */
+          match checkPTEPermission(ac, priv, mxr, do_sum, pattr, ext_pte, ext_ptw) {
+            PTE_Check_Failure(ext_ptw, ext_ptw_fail) => {
+/*            print("walk57: pte permission check failure"); */
+              PTW_Failure(ext_get_ptw_error(ext_ptw_fail), ext_ptw)
+            },
+	    PTE_Check_Success(ext_ptw) => {
+              if level > 0 then { /* superpage */
+                /* fixme hack: to get a mask of appropriate size */
+                let mask = shiftl(pte.PPNi() ^ pte.PPNi() ^ zero_extend(0b1), level * SV57_LEVEL_BITS) - 1;
+                if (pte.PPNi() & mask) != zero_extend(0b0) then {
+                  /* misaligned superpage mapping */
+/*                print("walk57: misaligned superpage mapping"); */
+                  PTW_Failure(PTW_Misaligned(), ext_ptw)
+                } else {
+                  /* add the appropriate bits of the VPN to the superpage PPN */
+                  let ppn = or_vec(pte.PPNi(), zero_extend(and_vec(va.VPNi()[43 .. 0], mask)));
+/*                let res = append(ppn, va.PgOfs());
+                  print("walk57: using superpage: pte.ppn=" ^ BitStr(pte.PPNi())
+                        ^ " ppn=" ^ BitStr(ppn) ^ " res=" ^ BitStr(res)); */
+                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                }
+              } else {
+                /* normal leaf PTE */
+/*              let res = append(pte.PPNi(), va.PgOfs());
+                print("walk57: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
+                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/* TLB management: single entry for now */
+
+// ideally we would use the below form:
+// type TLB57_Entry = TLB_Entry(sizeof(asid64), sizeof(vaddr57), sizeof(paddr64), sizeof(pte64))
+type TLB57_Entry = TLB_Entry(16, 57, 56, 64)
+register tlb57 : option(TLB57_Entry)
+
+val lookup_TLB57 : (asid64, vaddr57) -> option((nat, TLB57_Entry)) effect {rreg}
+function lookup_TLB57(asid, vaddr) =
+  match tlb57 {
+    None()  => None(),
+    Some(e) => if match_TLB_Entry(e, asid, vaddr) then Some((0, e)) else None()
+  }
+
+val add_to_TLB57 : (asid64, vaddr57, paddr64, SV57_PTE, paddr64, nat, bool) -> unit effect {wreg, rreg}
+function add_to_TLB57(asid, vAddr, pAddr, pte, pteAddr, level, global) = {
+  let ent : TLB57_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, SV57_LEVEL_BITS);
+  tlb57 = Some(ent)
+}
+
+function write_TLB57(idx : nat, ent : TLB57_Entry) -> unit =
+  tlb57 = Some(ent)
+
+val flush_TLB57 : (option(asid64), option(vaddr57)) -> unit effect {rreg, wreg}
+function flush_TLB57(asid, addr) =
+  match (tlb57) {
+    None()  => (),
+    Some(e) => if   flush_TLB_Entry(e, asid, addr)
+               then tlb57 = None()
+               else ()
+  }
+
+/* address translation */
+
+val translate57 : (asid64, paddr64, vaddr57, AccessType(ext_access_type), Privilege, bool, bool, nat, ext_ptw) -> TR_Result(paddr64, PTW_Error) effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
+function translate57(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = {
+  match lookup_TLB57(asid, vAddr) {
+    Some(idx, ent) => {
+/*    print("translate57: TLB57 hit for " ^ BitStr(vAddr)); */
+      let  pte = Mk_SV57_PTE(ent.pte);
+      let  ext_pte = pte.Ext();
+      let  pteBits = Mk_PTE_Bits(pte.BITS());
+      match checkPTEPermission(ac, priv, mxr, do_sum, pteBits, ext_pte, ext_ptw) {
+        PTE_Check_Failure(ext_ptw, ext_ptw_fail) => { TR_Failure(ext_get_ptw_error(ext_ptw_fail), ext_ptw) },
+        PTE_Check_Success(ext_ptw) => {
+          match update_PTE_Bits(pteBits, ac, ext_pte) {
+            None()           => TR_Address(or_vec(ent.pAddr, zero_extend(and_vec(vAddr[55 .. 0], ent.vAddrMask[55 .. 0]))), ext_ptw),
+            Some(pbits, ext) => {
+              if not(plat_enable_dirty_update())
+              then {
+                /* pte needs dirty/accessed update but that is not enabled */
+                TR_Failure(PTW_PTE_Update(), ext_ptw)
+              } else {
+                /* update PTE entry and TLB */
+                n_pte = update_BITS(pte, pbits.bits());
+                n_pte = update_Ext(n_pte, ext);
+                n_ent : TLB57_Entry = ent;
+                n_ent.pte = n_pte.bits();
+                write_TLB57(idx, n_ent);
+                /* update page table */
+                match mem_write_value_priv(zero_extend(ent.pteAddr), 8, n_pte.bits(), Supervisor, false, false, false) {
+                  MemValue(_)     => (),
+                  MemException(e) => internal_error(__FILE__, __LINE__, "invalid physical address in TLB")
+                };
+                TR_Address(or_vec(ent.pAddr, zero_extend(and_vec(vAddr[55 .. 0], ent.vAddrMask[55 .. 0]))), ext_ptw)
+              }
+            }
+          }
+        }
+      }
+    },
+    None() => {
+      match walk57(vAddr, ac, priv, mxr, do_sum, ptb, level, false, ext_ptw) {
+        PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
+        PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw) => {
+          match update_PTE_Bits(Mk_PTE_Bits(pte.BITS()), ac, pte.Ext()) {
+            None() => {
+              add_to_TLB57(asid, vAddr, pAddr, pte, pteAddr, level, global);
+              TR_Address(pAddr, ext_ptw)
+            },
+            Some(pbits, ext) =>
+              if not(plat_enable_dirty_update())
+              then {
+                /* pte needs dirty/accessed update but that is not enabled */
+                TR_Failure(PTW_PTE_Update(), ext_ptw)
+              } else {
+                w_pte : SV57_PTE = update_BITS(pte, pbits.bits());
+		w_pte : SV57_PTE = update_Ext(w_pte, ext);
+                match mem_write_value_priv(zero_extend(pteAddr), 8, w_pte.bits(), Supervisor, false, false, false) {
+                  MemValue(_) => {
+                    add_to_TLB57(asid, vAddr, pAddr, w_pte, pteAddr, level, global);
+                    TR_Address(pAddr, ext_ptw)
+                  },
+                  MemException(e) => {
+                    /* pte is not in valid memory */
+                    TR_Failure(PTW_Access(), ext_ptw)
+                  }
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+}
+
+function init_vmem_sv57() -> unit = {
+  tlb57 = None()
+}

--- a/prover_snapshots/coq/RV32/riscv.v
+++ b/prover_snapshots/coq/RV32/riscv.v
@@ -1600,10 +1600,11 @@ Definition SATPMode_of_num (arg_ : Z) `{ArithFact ((0 <=? arg_) && (arg_ <=? 3))
    if sumbool_of_bool (Z.eqb l__247 0) then Sbare
    else if sumbool_of_bool (Z.eqb l__247 1) then Sv32
    else if sumbool_of_bool (Z.eqb l__247 2) then Sv39
-   else Sv48.
+   else if sumbool_of_bool (Z.eqb l__247 3) then Sv48
+   else Sv57.
 
 Definition num_of_SATPMode (arg_ : SATPMode) : {e : Z & ArithFact ((0 <=? e) && (e <=? 3))} :=
-   build_ex (match arg_ with | Sbare => 0 | Sv32 => 1 | Sv39 => 2 | Sv48 => 3 end).
+   build_ex (match arg_ with | Sbare => 0 | Sv32 => 1 | Sv39 => 2 | Sv48 => 3 | Sv57 => 4 end).
 
 Definition satp64Mode_of_bits (a : Architecture) (m : mword 4) : option SATPMode :=
    match (a, m) with
@@ -1617,6 +1618,7 @@ Definition satp64Mode_of_bits (a : Architecture) (m : mword 4) : option SATPMode
         | (RV64, b__0) =>
            if eq_vec b__0 (Ox"8"  : mword 4) then Some Sv39
            else if eq_vec b__0 (Ox"9"  : mword 4) then Some Sv48
+           else if eq_vec b__0 (Ox"A"  : mword 4) then Some Sv57
            else match (RV64, b__0) with | (_, _) => None end
         | (_, _) => None
         end
@@ -13112,6 +13114,238 @@ Definition _update_SV48_PTE_BITS (v : SV48_PTE) (x : mword 8) : SV48_PTE :=
      SV48_PTE_SV48_PTE_chunk_0 :=
        (update_subrange_vec_dec v.(SV48_PTE_SV48_PTE_chunk_0) 7 0 (subrange_vec_dec x 7 0)) ]}.
 
+Definition SV57_LEVEL_BITS := 9.
+Hint Unfold SV57_LEVEL_BITS : sail.
+Definition SV57_LEVELS := 5.
+Hint Unfold SV57_LEVELS : sail.
+Definition PTE57_LOG_SIZE := 3.
+Hint Unfold PTE57_LOG_SIZE : sail.
+Definition PTE57_SIZE := 8.
+Hint Unfold PTE57_SIZE : sail.
+Definition Mk_SV57_Vaddr (v : mword 57) : SV57_Vaddr :=
+   {| SV57_Vaddr_SV57_Vaddr_chunk_0 := (subrange_vec_dec v 56 0) |}.
+
+Definition _get_SV57_Vaddr_bits (v : SV57_Vaddr) : mword 57 :=
+   subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 56 0.
+
+Definition _set_SV57_Vaddr_bits
+(r_ref : register_ref regstate register_value SV57_Vaddr) (v : mword 57)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Vaddr_SV57_Vaddr_chunk_0) 56 0 (subrange_vec_dec v 56 0)) ]}
+      : SV57_Vaddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Vaddr_bits (v : SV57_Vaddr) (x : mword 57) : SV57_Vaddr :=
+   {[ v with
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 56 0 (subrange_vec_dec x 56 0)) ]}.
+
+Definition _get_SV57_Vaddr_VPNi (v : SV57_Vaddr) : mword 27 :=
+   subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 38 12.
+
+Definition _set_SV57_Vaddr_VPNi
+(r_ref : register_ref regstate register_value SV57_Vaddr) (v : mword 27)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Vaddr_SV57_Vaddr_chunk_0) 38 12 (subrange_vec_dec v 26 0)) ]}
+      : SV57_Vaddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Vaddr_VPNi (v : SV57_Vaddr) (x : mword 27) : SV57_Vaddr :=
+   {[ v with
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 38 12 (subrange_vec_dec x 26 0)) ]}.
+
+Definition _get_SV57_Vaddr_PgOfs (v : SV57_Vaddr) : mword 12 :=
+   subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 11 0.
+
+Definition _set_SV57_Vaddr_PgOfs
+(r_ref : register_ref regstate register_value SV57_Vaddr) (v : mword 12)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Vaddr_SV57_Vaddr_chunk_0) 11 0 (subrange_vec_dec v 11 0)) ]}
+      : SV57_Vaddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Vaddr_PgOfs (v : SV57_Vaddr) (x : mword 12) : SV57_Vaddr :=
+   {[ v with
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Vaddr_SV57_Vaddr_chunk_0) 11 0 (subrange_vec_dec x 11 0)) ]}.
+
+Definition Mk_SV57_Paddr (v : mword 56) : SV57_Paddr :=
+   {| SV57_Paddr_SV57_Paddr_chunk_0 := (subrange_vec_dec v 55 0) |}.
+
+Definition _get_SV57_Paddr_bits (v : SV57_Paddr) : mword 56 :=
+   subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 55 0.
+
+Definition _set_SV57_Paddr_bits
+(r_ref : register_ref regstate register_value SV57_Paddr) (v : mword 56)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Paddr_SV57_Paddr_chunk_0) 55 0 (subrange_vec_dec v 55 0)) ]}
+      : SV57_Paddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Paddr_bits (v : SV57_Paddr) (x : mword 56) : SV57_Paddr :=
+   {[ v with
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 55 0 (subrange_vec_dec x 55 0)) ]}.
+
+Definition _get_SV57_Paddr_PPNi (v : SV57_Paddr) : mword 44 :=
+   subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 55 12.
+
+Definition _set_SV57_Paddr_PPNi
+(r_ref : register_ref regstate register_value SV57_Paddr) (v : mword 44)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Paddr_SV57_Paddr_chunk_0) 55 12 (subrange_vec_dec v 43 0)) ]}
+      : SV57_Paddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Paddr_PPNi (v : SV57_Paddr) (x : mword 44) : SV57_Paddr :=
+   {[ v with
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 55 12 (subrange_vec_dec x 43 0)) ]}.
+
+Definition _get_SV57_Paddr_PgOfs (v : SV57_Paddr) : mword 12 :=
+   subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 11 0.
+
+Definition _set_SV57_Paddr_PgOfs
+(r_ref : register_ref regstate register_value SV57_Paddr) (v : mword 12)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_Paddr_SV57_Paddr_chunk_0) 11 0 (subrange_vec_dec v 11 0)) ]}
+      : SV57_Paddr in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_Paddr_PgOfs (v : SV57_Paddr) (x : mword 12) : SV57_Paddr :=
+   {[ v with
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_Paddr_SV57_Paddr_chunk_0) 11 0 (subrange_vec_dec x 11 0)) ]}.
+
+Definition Mk_SV57_PTE (v : mword 64) : SV57_PTE :=
+   {| SV57_PTE_SV57_PTE_chunk_0 := (subrange_vec_dec v 63 0) |}.
+
+Definition _get_SV57_PTE_bits (v : SV57_PTE) : mword 64 :=
+   subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 63 0.
+
+Definition _set_SV57_PTE_bits (r_ref : register_ref regstate register_value SV57_PTE) (v : mword 64)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_PTE_SV57_PTE_chunk_0) 63 0 (subrange_vec_dec v 63 0)) ]}
+      : SV57_PTE in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_PTE_bits (v : SV57_PTE) (x : mword 64) : SV57_PTE :=
+   {[ v with
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 63 0 (subrange_vec_dec x 63 0)) ]}.
+
+Definition _get_SV57_PTE_Ext (v : SV57_PTE) : mword 10 :=
+   subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 63 54.
+
+Definition _set_SV57_PTE_Ext (r_ref : register_ref regstate register_value SV57_PTE) (v : mword 10)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_PTE_SV57_PTE_chunk_0) 63 54 (subrange_vec_dec v 9 0)) ]}
+      : SV57_PTE in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_PTE_Ext (v : SV57_PTE) (x : mword 10) : SV57_PTE :=
+   {[ v with
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 63 54 (subrange_vec_dec x 9 0)) ]}.
+
+Definition _get_SV57_PTE_PPNi (v : SV57_PTE) : mword 44 :=
+   subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 53 10.
+
+Definition _set_SV57_PTE_PPNi (r_ref : register_ref regstate register_value SV57_PTE) (v : mword 44)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_PTE_SV57_PTE_chunk_0) 53 10 (subrange_vec_dec v 43 0)) ]}
+      : SV57_PTE in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_PTE_PPNi (v : SV57_PTE) (x : mword 44) : SV57_PTE :=
+   {[ v with
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 53 10 (subrange_vec_dec x 43 0)) ]}.
+
+Definition _get_SV57_PTE_RSW (v : SV57_PTE) : mword 2 :=
+   subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 9 8.
+
+Definition _set_SV57_PTE_RSW (r_ref : register_ref regstate register_value SV57_PTE) (v : mword 2)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_PTE_SV57_PTE_chunk_0) 9 8 (subrange_vec_dec v 1 0)) ]}
+      : SV57_PTE in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_PTE_RSW (v : SV57_PTE) (x : mword 2) : SV57_PTE :=
+   {[ v with
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 9 8 (subrange_vec_dec x 1 0)) ]}.
+
+Definition _get_SV57_PTE_BITS (v : SV57_PTE) : mword 8 :=
+   subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 7 0.
+
+Definition _set_SV57_PTE_BITS (r_ref : register_ref regstate register_value SV57_PTE) (v : mword 8)
+: M (unit) :=
+   (reg_deref r_ref) >>= fun r =>
+   let r :=
+     {[ r with
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         (update_subrange_vec_dec r.(SV57_PTE_SV57_PTE_chunk_0) 7 0 (subrange_vec_dec v 7 0)) ]}
+      : SV57_PTE in
+   write_reg r_ref r
+    : M (unit).
+
+Definition _update_SV57_PTE_BITS (v : SV57_PTE) (x : mword 8) : SV57_PTE :=
+   {[ v with
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       (update_subrange_vec_dec v.(SV57_PTE_SV57_PTE_chunk_0) 7 0 (subrange_vec_dec x 7 0)) ]}.
+       
 Definition make_TLB_Entry {asidlen : Z} {valen : Z} {palen : Z} {ptelen : Z}
 (asid : mword asidlen) (global : bool) (vAddr : mword valen) (pAddr : mword palen)
 (pte : mword ptelen) (level : Z) (pteAddr : mword palen) (levelBitSize : Z)

--- a/prover_snapshots/coq/RV32/riscv_types.v
+++ b/prover_snapshots/coq/RV32/riscv_types.v
@@ -419,7 +419,7 @@ Decidable_eq_from_dec ExtStatus_eq_dec.
 
 Definition satp_mode  : Type := bits 4.
 
-Inductive SATPMode := Sbare | Sv32 | Sv39 | Sv48.
+Inductive SATPMode := Sbare | Sv32 | Sv39 | Sv48 | Sv57.
 Scheme Equality for SATPMode.
 Instance Decidable_eq_SATPMode :
 forall (x y : SATPMode), Decidable (x = y) :=
@@ -576,6 +576,21 @@ Record SV48_Vaddr  := { SV48_Vaddr_SV48_Vaddr_chunk_0 : mword 48; }.
 Arguments SV48_Vaddr : clear implicits.
 Notation "{[ r 'with' 'SV48_Vaddr_SV48_Vaddr_chunk_0' := e ]}" :=
   {| SV48_Vaddr_SV48_Vaddr_chunk_0 := e |} (only parsing).
+
+Record SV57_PTE  := { SV57_PTE_SV57_PTE_chunk_0 : mword 64; }.
+Arguments SV57_PTE : clear implicits.
+Notation "{[ r 'with' 'SV57_PTE_SV57_PTE_chunk_0' := e ]}" :=
+  {| SV57_PTE_SV57_PTE_chunk_0 := e |} (only parsing).
+
+Record SV57_Paddr  := { SV57_Paddr_SV57_Paddr_chunk_0 : mword 56; }.
+Arguments SV57_Paddr : clear implicits.
+Notation "{[ r 'with' 'SV57_Paddr_SV57_Paddr_chunk_0' := e ]}" :=
+  {| SV57_Paddr_SV57_Paddr_chunk_0 := e |} (only parsing).
+
+Record SV57_Vaddr  := { SV57_Vaddr_SV57_Vaddr_chunk_0 : mword 57; }.
+Arguments SV57_Vaddr : clear implicits.
+Notation "{[ r 'with' 'SV57_Vaddr_SV57_Vaddr_chunk_0' := e ]}" :=
+  {| SV57_Vaddr_SV57_Vaddr_chunk_0 := e |} (only parsing).
 
 Record Satp32  := { Satp32_Satp32_chunk_0 : mword 32; }.
 Arguments Satp32 : clear implicits.
@@ -736,7 +751,11 @@ Definition vaddr39  : Type := bits 39.
 
 Definition vaddr48  : Type := bits 48.
 
+Definition vaddr57  : Type := bits 57.
+
 Definition pte48  : Type := bits 64.
+
+Definition pte57  : Type := bits 64.
 
 Inductive PTW_Result {paddr : Type} {pte : Type} :=
   | PTW_Success : (paddr * pte * paddr * {n : Z & ArithFact (n >=? 0)} * bool * ext_ptw) -> PTW_Result

--- a/prover_snapshots/coq/RV64/riscv_types.v
+++ b/prover_snapshots/coq/RV64/riscv_types.v
@@ -469,7 +469,7 @@ Decidable_eq_from_dec ExtStatus_eq_dec.
 
 Definition satp_mode  : Type := bits 4.
 
-Inductive SATPMode := Sbare | Sv32 | Sv39 | Sv48.
+Inductive SATPMode := Sbare | Sv32 | Sv39 | Sv48 | Sv57.
 Scheme Equality for SATPMode.
 Instance Decidable_eq_SATPMode :
 forall (x y : SATPMode), Decidable (x = y) :=
@@ -585,6 +585,21 @@ Record SV48_Vaddr  := { SV48_Vaddr_SV48_Vaddr_chunk_0 : mword 48; }.
 Arguments SV48_Vaddr : clear implicits.
 Notation "{[ r 'with' 'SV48_Vaddr_SV48_Vaddr_chunk_0' := e ]}" :=
   {| SV48_Vaddr_SV48_Vaddr_chunk_0 := e |} (only parsing).
+
+Record SV57_PTE  := { SV57_PTE_SV57_PTE_chunk_0 : mword 64; }.
+Arguments SV57_PTE : clear implicits.
+Notation "{[ r 'with' 'SV57_PTE_SV57_PTE_chunk_0' := e ]}" :=
+  {| SV57_PTE_SV57_PTE_chunk_0 := e |} (only parsing).
+
+Record SV57_Paddr  := { SV57_Paddr_SV57_Paddr_chunk_0 : mword 56; }.
+Arguments SV57_Paddr : clear implicits.
+Notation "{[ r 'with' 'SV57_Paddr_SV57_Paddr_chunk_0' := e ]}" :=
+  {| SV57_Paddr_SV57_Paddr_chunk_0 := e |} (only parsing).
+
+Record SV57_Vaddr  := { SV57_Vaddr_SV57_Vaddr_chunk_0 : mword 57; }.
+Arguments SV57_Vaddr : clear implicits.
+Notation "{[ r 'with' 'SV57_Vaddr_SV57_Vaddr_chunk_0' := e ]}" :=
+  {| SV57_Vaddr_SV57_Vaddr_chunk_0 := e |} (only parsing).
 
 Record Satp32  := { Satp32_Satp32_chunk_0 : mword 32; }.
 Arguments Satp32 : clear implicits.
@@ -745,7 +760,11 @@ Definition vaddr39  : Type := bits 39.
 
 Definition vaddr48  : Type := bits 48.
 
+Definition vaddr57  : Type := bits 57.
+
 Definition pte48  : Type := bits 64.
+
+Definition pte57  : Type := bits 64.
 
 Inductive PTW_Result {paddr : Type} {pte : Type} :=
   | PTW_Success : (paddr * pte * paddr * {n : Z & ArithFact (n >=? 0)} * bool * ext_ptw) -> PTW_Result
@@ -799,6 +818,8 @@ Definition TLB39_Entry  : Type := TLB_Entry 16 39 56 64.
 
 Definition TLB48_Entry  : Type := TLB_Entry 16 48 56 64.
 
+Definition TLB57_Entry  : Type := TLB_Entry 16 57 56 64.
+
 Inductive register_value  :=
   | Regval_vector : list register_value -> register_value
   | Regval_list : list register_value -> register_value
@@ -819,6 +840,7 @@ Inductive register_value  :=
   | Regval_Sinterrupts : Sinterrupts -> register_value
   | Regval_TLB_Entry_16_39_56_64 : TLB_Entry 16 39 56 64 -> register_value
   | Regval_TLB_Entry_16_48_56_64 : TLB_Entry 16 48 56 64 -> register_value
+  | Regval_TLB_Entry_16_57_56_64 : TLB_Entry 16 57 56 64 -> register_value
   | Regval_bit : bitU -> register_value
   | Regval_bitvector_32_dec : mword 32 -> register_value
   | Regval_bitvector_4_dec : mword 4 -> register_value
@@ -828,6 +850,7 @@ Arguments register_value : clear implicits.
 
 Record regstate  :=
   { satp : mword 64;
+    tlb57 : option (TLB_Entry 16 57 56 64);
     tlb48 : option (TLB_Entry 16 48 56 64);
     tlb39 : option (TLB_Entry 16 39 56 64);
     htif_payload_writes : mword 4;
@@ -979,6 +1002,10 @@ Arguments regstate : clear implicits.
 Notation "{[ r 'with' 'satp' := e ]}" :=
   match r with Build_regstate _ f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 f32 f33 f34 f35 f36 f37 f38 f39 f40 f41 f42 f43 f44 f45 f46 f47 f48 f49 f50 f51 f52 f53 f54 f55 f56 f57 f58 f59 f60 f61 f62 f63 f64 f65 f66 f67 f68 f69 f70 f71 f72 f73 f74 f75 f76 f77 f78 f79 f80 f81 f82 f83 f84 f85 f86 f87 f88 f89 f90 f91 f92 f93 f94 f95 f96 f97 f98 f99 f100 f101 f102 f103 f104 f105 f106 f107 f108 f109 f110 f111 f112 f113 f114 f115 f116 f117 f118 f119 f120 f121 f122 f123 f124 f125 f126 f127 f128 f129 f130 f131 f132 f133 f134 f135 f136 f137 f138 f139 f140 f141 f142 f143 f144 f145 f146 f147 =>
     Build_regstate e f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 f32 f33 f34 f35 f36 f37 f38 f39 f40 f41 f42 f43 f44 f45 f46 f47 f48 f49 f50 f51 f52 f53 f54 f55 f56 f57 f58 f59 f60 f61 f62 f63 f64 f65 f66 f67 f68 f69 f70 f71 f72 f73 f74 f75 f76 f77 f78 f79 f80 f81 f82 f83 f84 f85 f86 f87 f88 f89 f90 f91 f92 f93 f94 f95 f96 f97 f98 f99 f100 f101 f102 f103 f104 f105 f106 f107 f108 f109 f110 f111 f112 f113 f114 f115 f116 f117 f118 f119 f120 f121 f122 f123 f124 f125 f126 f127 f128 f129 f130 f131 f132 f133 f134 f135 f136 f137 f138 f139 f140 f141 f142 f143 f144 f145 f146 f147
+      end.
+Notation "{[ r 'with' 'tlb57' := e ]}" :=
+  match r with Build_regstate f0 _ f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 f32 f33 f34 f35 f36 f37 f38 f39 f40 f41 f42 f43 f44 f45 f46 f47 f48 f49 f50 f51 f52 f53 f54 f55 f56 f57 f58 f59 f60 f61 f62 f63 f64 f65 f66 f67 f68 f69 f70 f71 f72 f73 f74 f75 f76 f77 f78 f79 f80 f81 f82 f83 f84 f85 f86 f87 f88 f89 f90 f91 f92 f93 f94 f95 f96 f97 f98 f99 f100 f101 f102 f103 f104 f105 f106 f107 f108 f109 f110 f111 f112 f113 f114 f115 f116 f117 f118 f119 f120 f121 f122 f123 f124 f125 f126 f127 f128 f129 f130 f131 f132 f133 f134 f135 f136 f137 f138 f139 f140 f141 f142 f143 f144 f145 f146 f147 =>
+    Build_regstate f0 e f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 f32 f33 f34 f35 f36 f37 f38 f39 f40 f41 f42 f43 f44 f45 f46 f47 f48 f49 f50 f51 f52 f53 f54 f55 f56 f57 f58 f59 f60 f61 f62 f63 f64 f65 f66 f67 f68 f69 f70 f71 f72 f73 f74 f75 f76 f77 f78 f79 f80 f81 f82 f83 f84 f85 f86 f87 f88 f89 f90 f91 f92 f93 f94 f95 f96 f97 f98 f99 f100 f101 f102 f103 f104 f105 f106 f107 f108 f109 f110 f111 f112 f113 f114 f115 f116 f117 f118 f119 f120 f121 f122 f123 f124 f125 f126 f127 f128 f129 f130 f131 f132 f133 f134 f135 f136 f137 f138 f139 f140 f141 f142 f143 f144 f145 f146 f147
       end.
 Notation "{[ r 'with' 'tlb48' := e ]}" :=
   match r with Build_regstate f0 _ f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18 f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29 f30 f31 f32 f33 f34 f35 f36 f37 f38 f39 f40 f41 f42 f43 f44 f45 f46 f47 f48 f49 f50 f51 f52 f53 f54 f55 f56 f57 f58 f59 f60 f61 f62 f63 f64 f65 f66 f67 f68 f69 f70 f71 f72 f73 f74 f75 f76 f77 f78 f79 f80 f81 f82 f83 f84 f85 f86 f87 f88 f89 f90 f91 f92 f93 f94 f95 f96 f97 f98 f99 f100 f101 f102 f103 f104 f105 f106 f107 f108 f109 f110 f111 f112 f113 f114 f115 f116 f117 f118 f119 f120 f121 f122 f123 f124 f125 f126 f127 f128 f129 f130 f131 f132 f133 f134 f135 f136 f137 f138 f139 f140 f141 f142 f143 f144 f145 f146 f147 =>
@@ -1655,6 +1682,13 @@ Definition TLB_Entry_16_48_56_64_of_regval (merge_var : register_value)
 Definition regval_of_TLB_Entry_16_48_56_64 (v : TLB_Entry 16 48 56 64) : register_value :=
    Regval_TLB_Entry_16_48_56_64 v.
 
+Definition TLB_Entry_16_57_56_64_of_regval (merge_var : register_value)
+: option (TLB_Entry 16 57 56 64) :=
+   match merge_var with | Regval_TLB_Entry_16_57_56_64 v => Some v | _ => None end.
+
+Definition regval_of_TLB_Entry_16_57_56_64 (v : TLB_Entry 16 57 56 64) : register_value :=
+   Regval_TLB_Entry_16_57_56_64 v.
+
 Definition bit_of_regval (merge_var : register_value) : option bitU :=
    match merge_var with | Regval_bit v => Some v | _ => None end.
 
@@ -1710,6 +1744,13 @@ Definition satp_ref := {|
   write_to := (fun v s => ({[ s with satp := v ]}));
   of_regval := (fun v => bitvector_64_dec_of_regval v);
   regval_of := (fun v => regval_of_bitvector_64_dec v) |}.
+
+Definition tlb57_ref := {|
+  name := "tlb57";
+  read_from := (fun s => s.(tlb57));
+  write_to := (fun v s => ({[ s with tlb57 := v ]}));
+  of_regval := (fun v => option_of_regval (fun v => TLB_Entry_16_57_56_64_of_regval v) v);
+  regval_of := (fun v => regval_of_option (fun v => regval_of_TLB_Entry_16_57_56_64 v) v) |}.
 
 Definition tlb48_ref := {|
   name := "tlb48";
@@ -2743,6 +2784,7 @@ Definition PC_ref := {|
 Local Open Scope string.
 Definition get_regval (reg_name : string) (s : regstate) : option register_value :=
   if string_dec reg_name "satp" then Some (satp_ref.(regval_of) (satp_ref.(read_from) s)) else
+  if string_dec reg_name "tlb57" then Some (tlb57_ref.(regval_of) (tlb57_ref.(read_from) s)) else
   if string_dec reg_name "tlb48" then Some (tlb48_ref.(regval_of) (tlb48_ref.(read_from) s)) else
   if string_dec reg_name "tlb39" then Some (tlb39_ref.(regval_of) (tlb39_ref.(read_from) s)) else
   if string_dec reg_name "htif_payload_writes" then Some (htif_payload_writes_ref.(regval_of) (htif_payload_writes_ref.(read_from) s)) else
@@ -2894,6 +2936,7 @@ Definition get_regval (reg_name : string) (s : regstate) : option register_value
 
 Definition set_regval (reg_name : string) (v : register_value) (s : regstate) : option regstate :=
   if string_dec reg_name "satp" then option_map (fun v => satp_ref.(write_to) v s) (satp_ref.(of_regval) v) else
+  if string_dec reg_name "tlb57" then option_map (fun v => tlb57_ref.(write_to) v s) (tlb57_ref.(of_regval) v) else
   if string_dec reg_name "tlb48" then option_map (fun v => tlb48_ref.(write_to) v s) (tlb48_ref.(of_regval) v) else
   if string_dec reg_name "tlb39" then option_map (fun v => tlb39_ref.(write_to) v s) (tlb39_ref.(of_regval) v) else
   if string_dec reg_name "htif_payload_writes" then option_map (fun v => htif_payload_writes_ref.(write_to) v s) (htif_payload_writes_ref.(of_regval) v) else

--- a/prover_snapshots/hol4/RV32/riscvScript.sml
+++ b/prover_snapshots/hol4/RV32/riscvScript.sml
@@ -2328,15 +2328,15 @@ val _ = Define `
     (let l__247 = arg_ in
    if (((l__247 = (( 0 : int):ii)))) then Sbare
    else if (((l__247 = (( 1 : int):ii)))) then Sv32
-   else if (((l__247 = (( 2 : int):ii)))) then Sv39
-   else Sv48))`;
+   else if (((l__247 = (( 3 : int):ii)))) then Sv48
+   else Sv57))`;
 
 
 (*val num_of_SATPMode : SATPMode -> integer*)
 
 val _ = Define `
  ((num_of_SATPMode:SATPMode -> int) arg_=
-    ((case arg_ of   Sbare => (( 0 : int):ii) | Sv32 => (( 1 : int):ii) | Sv39 => (( 2 : int):ii) | Sv48 => (( 3 : int):ii) )))`;
+    ((case arg_ of   Sbare => (( 0 : int):ii) | Sv32 => (( 1 : int):ii) | Sv39 => (( 2 : int):ii) | Sv48 => (( 3 : int):ii) | Sv57 => (( 4 : int):ii) )))`;
 
 
 (*val satp64Mode_of_bits : Architecture -> mword ty4 -> maybe SATPMode*)
@@ -2354,6 +2354,7 @@ val _ = Define `
         | (RV64, b__0) =>
            if (((b__0 = (0x8w :  4 words$word)))) then SOME Sv39
            else if (((b__0 = (0x9w :  4 words$word)))) then SOME Sv48
+           else if (((b__0 = (0xAw :  4 words$word)))) then SOME Sv57
            else (case (RV64, b__0) of   (_, _) => NONE )
         | (_, _) => NONE
         )
@@ -4424,6 +4425,12 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48 -> SV48_Vaddr*)
 
+(*val _update_SV57_PTE_bits : SV57_PTE -> mword ty64 -> SV57_PTE*)
+
+(*val _update_SV57_Paddr_bits : SV57_Paddr -> mword ty56 -> SV57_Paddr*)
+
+(*val _update_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57 -> SV57_Vaddr*)
+
 (*val _update_Satp32_bits : Satp32 -> mword ty32 -> Satp32*)
 
 (*val _update_Satp64_bits : Satp64 -> mword ty64 -> Satp64*)
@@ -4480,6 +4487,12 @@ val _ = Define `
 
 (*val _get_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48*)
 
+(*val _get_SV57_PTE_bits : SV57_PTE -> mword ty64*)
+
+(*val _get_SV57_Paddr_bits : SV57_Paddr -> mword ty56*)
+
+(*val _get_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57*)
+
 (*val _get_Satp32_bits : Satp32 -> mword ty32*)
 
 (*val _get_Satp64_bits : Satp64 -> mword ty64*)
@@ -4535,6 +4548,12 @@ val _ = Define `
 (*val _set_SV48_Paddr_bits : register_ref regstate register_value SV48_Paddr -> mword ty56 -> M unit*)
 
 (*val _set_SV48_Vaddr_bits : register_ref regstate register_value SV48_Vaddr -> mword ty48 -> M unit*)
+
+(*val _set_SV57_PTE_bits : register_ref regstate register_value SV57_PTE -> mword ty64 -> M unit*)
+
+(*val _set_SV57_Paddr_bits : register_ref regstate register_value SV57_Paddr -> mword ty56 -> M unit*)
+
+(*val _set_SV57_Vaddr_bits : register_ref regstate register_value SV57_Vaddr -> mword ty57 -> M unit*)
 
 (*val _set_Satp32_bits : register_ref regstate register_value Satp32 -> mword ty32 -> M unit*)
 
@@ -16369,13 +16388,19 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27 -> SV48_Vaddr*)
 
+(*val _update_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27 -> SV57_Vaddr*)
+
 (*val _get_SV39_Vaddr_VPNi : SV39_Vaddr -> mword ty27*)
 
 (*val _get_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27*)
 
+(*val _get_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27*)
+
 (*val _set_SV39_Vaddr_VPNi : register_ref regstate register_value SV39_Vaddr -> mword ty27 -> M unit*)
 
 (*val _set_SV48_Vaddr_VPNi : register_ref regstate register_value SV48_Vaddr -> mword ty27 -> M unit*)
+
+(*val _set_SV57_Vaddr_VPNi : register_ref regstate register_value SV57_Vaddr -> mword ty27 -> M unit*)
 
 (*val _get_SV32_Vaddr_PgOfs : SV32_Vaddr -> mword ty12*)
 
@@ -16419,6 +16444,10 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12 -> SV48_Vaddr*)
 
+(*val _update_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12 -> SV57_Paddr*)
+
+(*val _update_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12 -> SV57_Vaddr*)
+
 (*val _get_SV32_Paddr_PgOfs : SV32_Paddr -> mword ty12*)
 
 (*val _get_SV39_Paddr_PgOfs : SV39_Paddr -> mword ty12*)
@@ -16429,6 +16458,10 @@ val _ = Define `
 
 (*val _get_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12*)
 
+(*val _get_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12*)
+
+(*val _get_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12*)
+
 (*val _set_SV32_Paddr_PgOfs : register_ref regstate register_value SV32_Paddr -> mword ty12 -> M unit*)
 
 (*val _set_SV39_Paddr_PgOfs : register_ref regstate register_value SV39_Paddr -> mword ty12 -> M unit*)
@@ -16438,6 +16471,10 @@ val _ = Define `
 (*val _set_SV48_Paddr_PgOfs : register_ref regstate register_value SV48_Paddr -> mword ty12 -> M unit*)
 
 (*val _set_SV48_Vaddr_PgOfs : register_ref regstate register_value SV48_Vaddr -> mword ty12 -> M unit*)
+
+(*val _set_SV57_Paddr_PgOfs : register_ref regstate register_value SV57_Paddr -> mword ty12 -> M unit*)
+
+(*val _set_SV57_Vaddr_PgOfs : register_ref regstate register_value SV57_Vaddr -> mword ty12 -> M unit*)
 
 (*val Mk_SV32_Paddr : mword ty34 -> SV32_Paddr*)
 
@@ -16514,6 +16551,10 @@ val _ = Define `
 
 (*val _update_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44 -> SV48_Paddr*)
 
+(*val _update_SV57_PTE_PPNi : SV57_PTE -> mword ty44 -> SV57_PTE*)
+
+(*val _update_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44 -> SV57_Paddr*)
+
 (*val _get_SV32_PTE_PPNi : SV32_PTE -> mword ty22*)
 
 (*val _get_SV39_PTE_PPNi : SV39_PTE -> mword ty44*)
@@ -16524,15 +16565,22 @@ val _ = Define `
 
 (*val _get_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44*)
 
+(*val _get_SV57_PTE_PPNi : SV57_PTE -> mword ty44*)
+
+(*val _get_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44*)
+
 (*val _set_SV32_PTE_PPNi : register_ref regstate register_value SV32_PTE -> mword ty22 -> M unit*)
 
 (*val _set_SV39_PTE_PPNi : register_ref regstate register_value SV39_PTE -> mword ty44 -> M unit*)
 
 (*val _set_SV39_Paddr_PPNi : register_ref regstate register_value SV39_Paddr -> mword ty44 -> M unit*)
-
 (*val _set_SV48_PTE_PPNi : register_ref regstate register_value SV48_PTE -> mword ty44 -> M unit*)
 
 (*val _set_SV48_Paddr_PPNi : register_ref regstate register_value SV48_Paddr -> mword ty44 -> M unit*)
+
+(*val _set_SV57_PTE_PPNi : register_ref regstate register_value SV57_PTE -> mword ty44 -> M unit*)
+
+(*val _set_SV57_Paddr_PPNi : register_ref regstate register_value SV57_Paddr -> mword ty44 -> M unit*)
 
 val _ = Define `
  ((get_SV32_Paddr_PgOfs:SV32_Paddr ->(12)words$word) v=
@@ -16654,13 +16702,19 @@ val _ = Define `
 
 (*val _update_SV48_PTE_RSW : SV48_PTE -> mword ty2 -> SV48_PTE*)
 
+(*val _update_SV57_PTE_RSW : SV57_PTE -> mword ty2 -> SV57_PTE*)
+
 (*val _get_SV39_PTE_RSW : SV39_PTE -> mword ty2*)
 
 (*val _get_SV48_PTE_RSW : SV48_PTE -> mword ty2*)
 
+(*val _get_SV57_PTE_RSW : SV57_PTE -> mword ty2*)
+
 (*val _set_SV39_PTE_RSW : register_ref regstate register_value SV39_PTE -> mword ty2 -> M unit*)
 
 (*val _set_SV48_PTE_RSW : register_ref regstate register_value SV48_PTE -> mword ty2 -> M unit*)
+
+(*val _set_SV57_PTE_RSW : register_ref regstate register_value SV57_PTE -> mword ty2 -> M unit*)
 
 (*val _get_SV32_PTE_BITS : SV32_PTE -> mword ty8*)
 
@@ -16697,13 +16751,19 @@ val _ = Define `
 
 (*val _update_SV48_PTE_BITS : SV48_PTE -> mword ty8 -> SV48_PTE*)
 
+(*val _update_SV57_PTE_BITS : SV57_PTE -> mword ty8 -> SV57_PTE*)
+
 (*val _get_SV39_PTE_BITS : SV39_PTE -> mword ty8*)
 
 (*val _get_SV48_PTE_BITS : SV48_PTE -> mword ty8*)
 
+(*val _get_SV57_PTE_BITS : SV57_PTE -> mword ty8*)
+
 (*val _set_SV39_PTE_BITS : register_ref regstate register_value SV39_PTE -> mword ty8 -> M unit*)
 
 (*val _set_SV48_PTE_BITS : register_ref regstate register_value SV48_PTE -> mword ty8 -> M unit*)
+
+(*val _set_SV57_PTE_BITS : register_ref regstate register_value SV57_PTE -> mword ty8 -> M unit*)
 
 (*val curAsid64 : mword ty64 -> mword ty16*)
 
@@ -17299,6 +17359,11 @@ val _ = Define `
            ((subrange_vec_dec x (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
           :  64 words$word)) |>)))`;
 
+(*val _update_SV57_PTE_Ext : SV57_PTE -> mword ty10 -> SV57_PTE*)
+
+(*val _get_SV57_PTE_Ext : SV57_PTE -> mword ty10*)
+
+(*val _set_SV57_PTE_Ext : register_ref regstate register_value SV57_PTE -> mword ty10 -> M unit*)
 
 val _ = Define `
  ((get_SV48_PTE_PPNi:SV48_PTE ->(44)words$word) v=
@@ -17375,6 +17440,325 @@ val _ = Define `
            ((subrange_vec_dec x (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
           :  64 words$word)) |>)))`;
 
+val _ = Define `
+((SV57_LEVEL_BITS:int)=  ((( 9 : int):ii)))`;
+
+
+val _ = Define `
+((SV57_LEVELS:int)=  ((( 5 : int):ii)))`;
+
+
+val _ = Define `
+((PTE57_LOG_SIZE:int)=  ((( 3 : int):ii)))`;
+
+
+val _ = Define `
+((PTE57_SIZE:int)=  ((( 8 : int):ii)))`;
+
+
+(*val Mk_SV57_Vaddr : mword ty57 -> SV57_Vaddr*)
+
+val _ = Define `
+ ((Mk_SV57_Vaddr:(57)words$word -> SV57_Vaddr) v=
+    (<| SV57_Vaddr_SV57_Vaddr_chunk_0 := ((subrange_vec_dec v (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_bits:SV57_Vaddr ->(57)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_bits:((regstate),(register_value),(SV57_Vaddr))register_ref ->(57)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_bits:SV57_Vaddr ->(57)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word))
+          :  57 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_VPNi:SV57_Vaddr ->(27)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)  :  27 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_VPNi:((regstate),(register_value),(SV57_Vaddr))register_ref ->(27)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)
+             ((subrange_vec_dec v (( 26 : int):ii) (( 0 : int):ii)  :  27 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_VPNi:SV57_Vaddr ->(27)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)
+           ((subrange_vec_dec x (( 26 : int):ii) (( 0 : int):ii)  :  27 words$word))
+          :  57 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_PgOfs:SV57_Vaddr ->(12)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_PgOfs:((regstate),(register_value),(SV57_Vaddr))register_ref ->(12)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_PgOfs:SV57_Vaddr ->(12)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+          :  57 words$word)) |>)))`;
+
+
+(*val Mk_SV57_Paddr : mword ty56 -> SV57_Paddr*)
+
+val _ = Define `
+ ((Mk_SV57_Paddr:(56)words$word -> SV57_Paddr) v=
+    (<| SV57_Paddr_SV57_Paddr_chunk_0 := ((subrange_vec_dec v (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_bits:SV57_Paddr ->(56)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_bits:((regstate),(register_value),(SV57_Paddr))register_ref ->(56)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_bits:SV57_Paddr ->(56)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word))
+          :  56 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_PPNi:SV57_Paddr ->(44)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)  :  44 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_PPNi:((regstate),(register_value),(SV57_Paddr))register_ref ->(44)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)
+             ((subrange_vec_dec v (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_PPNi:SV57_Paddr ->(44)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)
+           ((subrange_vec_dec x (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+          :  56 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_PgOfs:SV57_Paddr ->(12)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_PgOfs:((regstate),(register_value),(SV57_Paddr))register_ref ->(12)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_PgOfs:SV57_Paddr ->(12)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+          :  56 words$word)) |>)))`;
+
+
+(*val Mk_SV57_PTE : mword ty64 -> SV57_PTE*)
+
+val _ = Define `
+ ((Mk_SV57_PTE:(64)words$word -> SV57_PTE) v=
+    (<| SV57_PTE_SV57_PTE_chunk_0 := ((subrange_vec_dec v (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_bits:SV57_PTE ->(64)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_bits:((regstate),(register_value),(SV57_PTE))register_ref ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_bits:SV57_PTE ->(64)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_Ext:SV57_PTE ->(10)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)  :  10 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_Ext:((regstate),(register_value),(SV57_PTE))register_ref ->(10)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)
+             ((subrange_vec_dec v (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_Ext:SV57_PTE ->(10)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)
+           ((subrange_vec_dec x (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_PPNi:SV57_PTE ->(44)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)  :  44 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_PPNi:((regstate),(register_value),(SV57_PTE))register_ref ->(44)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)
+             ((subrange_vec_dec v (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_PPNi:SV57_PTE ->(44)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)
+           ((subrange_vec_dec x (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_RSW:SV57_PTE ->(2)words$word) v=  ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)  :  2 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_RSW:((regstate),(register_value),(SV57_PTE))register_ref ->(2)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)
+             ((subrange_vec_dec v (( 1 : int):ii) (( 0 : int):ii)  :  2 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_RSW:SV57_PTE ->(2)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)
+           ((subrange_vec_dec x (( 1 : int):ii) (( 0 : int):ii)  :  2 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_BITS:SV57_PTE ->(8)words$word) v=  ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_BITS:((regstate),(register_value),(SV57_PTE))register_ref ->(8)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_BITS:SV57_PTE ->(8)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
+          :  64 words$word)) |>)))`;
 
 (*val make_TLB_Entry : forall 'asidlen 'palen 'ptelen 'valen. Size 'asidlen, Size 'palen, Size 'ptelen, Size 'valen => mword 'asidlen -> bool -> mword 'valen -> mword 'palen -> mword 'ptelen -> ii -> mword 'palen -> ii -> M (TLB_Entry 'asidlen 'valen 'palen 'ptelen)*)
 

--- a/prover_snapshots/hol4/RV32/riscv_typesScript.sml
+++ b/prover_snapshots/hol4/RV32/riscv_typesScript.sml
@@ -427,7 +427,7 @@ val _ = Hol_datatype `
 val _ = type_abbrev( "satp_mode"  , ``: 4 bits``);
 
 val _ = Hol_datatype `
- SATPMode =   Sbare | Sv32 | Sv39 | Sv48`;
+ SATPMode =   Sbare | Sv32 | Sv39 | Sv48 | Sv57`;
 
 
 
@@ -583,6 +583,21 @@ val _ = Hol_datatype `
 
 val _ = Hol_datatype `
  SV48_Vaddr  = <| SV48_Vaddr_SV48_Vaddr_chunk_0 :  48 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_PTE  = <| SV57_PTE_SV57_PTE_chunk_0 :  64 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_Paddr  = <| SV57_Paddr_SV57_Paddr_chunk_0 :  56 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_Vaddr  = <| SV57_Vaddr_SV57_Vaddr_chunk_0 :  57 words$word  |>`;
 
 
 
@@ -750,7 +765,11 @@ val _ = type_abbrev( "vaddr39"  , ``: 39 bits``);
 
 val _ = type_abbrev( "vaddr48"  , ``: 48 bits``);
 
+val _ = type_abbrev( "vaddr57"  , ``: 57 bits``);
+
 val _ = type_abbrev( "pte48"  , ``: 64 bits``);
+
+val _ = type_abbrev( "pte57"  , ``: 64 bits``);
 
 val _ = Hol_datatype `
  PTW_Result =

--- a/prover_snapshots/hol4/RV64/riscvScript.sml
+++ b/prover_snapshots/hol4/RV64/riscvScript.sml
@@ -2328,15 +2328,15 @@ val _ = Define `
     (let l__240 = arg_ in
    if (((l__240 = (( 0 : int):ii)))) then Sbare
    else if (((l__240 = (( 1 : int):ii)))) then Sv32
-   else if (((l__240 = (( 2 : int):ii)))) then Sv39
-   else Sv48))`;
+   else if (((l__240 = (( 3 : int):ii)))) then Sv48
+   else Sv57))`;
 
 
 (*val num_of_SATPMode : SATPMode -> integer*)
 
 val _ = Define `
  ((num_of_SATPMode:SATPMode -> int) arg_=
-    ((case arg_ of   Sbare => (( 0 : int):ii) | Sv32 => (( 1 : int):ii) | Sv39 => (( 2 : int):ii) | Sv48 => (( 3 : int):ii) )))`;
+    ((case arg_ of   Sbare => (( 0 : int):ii) | Sv32 => (( 1 : int):ii) | Sv39 => (( 2 : int):ii) | Sv48 => (( 3 : int):ii) | Sv57 => (( 4 : int):ii) )))`;
 
 
 (*val satp64Mode_of_bits : Architecture -> mword ty4 -> maybe SATPMode*)
@@ -2354,6 +2354,7 @@ val _ = Define `
         | (RV64, b__0) =>
            if (((b__0 = (0x8w :  4 words$word)))) then SOME Sv39
            else if (((b__0 = (0x9w :  4 words$word)))) then SOME Sv48
+           else if (((b__0 = (0xAw :  4 words$word)))) then SOME Sv57
            else (case (RV64, b__0) of   (_, _) => NONE )
         | (_, _) => NONE
         )
@@ -4424,6 +4425,12 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48 -> SV48_Vaddr*)
 
+(*val _update_SV57_PTE_bits : SV57_PTE -> mword ty64 -> SV57_PTE*)
+
+(*val _update_SV57_Paddr_bits : SV57_Paddr -> mword ty56 -> SV57_Paddr*)
+
+(*val _update_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57 -> SV57_Vaddr*)
+
 (*val _update_Satp32_bits : Satp32 -> mword ty32 -> Satp32*)
 
 (*val _update_Satp64_bits : Satp64 -> mword ty64 -> Satp64*)
@@ -4480,6 +4487,12 @@ val _ = Define `
 
 (*val _get_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48*)
 
+(*val _get_SV57_PTE_bits : SV57_PTE -> mword ty64*)
+
+(*val _get_SV57_Paddr_bits : SV57_Paddr -> mword ty56*)
+
+(*val _get_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57*)
+
 (*val _get_Satp32_bits : Satp32 -> mword ty32*)
 
 (*val _get_Satp64_bits : Satp64 -> mword ty64*)
@@ -4535,6 +4548,12 @@ val _ = Define `
 (*val _set_SV48_Paddr_bits : register_ref regstate register_value SV48_Paddr -> mword ty56 -> M unit*)
 
 (*val _set_SV48_Vaddr_bits : register_ref regstate register_value SV48_Vaddr -> mword ty48 -> M unit*)
+
+(*val _set_SV57_PTE_bits : register_ref regstate register_value SV57_PTE -> mword ty64 -> M unit*)
+
+(*val _set_SV57_Paddr_bits : register_ref regstate register_value SV57_Paddr -> mword ty56 -> M unit*)
+
+(*val _set_SV57_Vaddr_bits : register_ref regstate register_value SV57_Vaddr -> mword ty57 -> M unit*)
 
 (*val _set_Satp32_bits : register_ref regstate register_value Satp32 -> mword ty32 -> M unit*)
 
@@ -16390,13 +16409,19 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27 -> SV48_Vaddr*)
 
+(*val _update_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27 -> SV57_Vaddr*)
+
 (*val _get_SV39_Vaddr_VPNi : SV39_Vaddr -> mword ty27*)
 
 (*val _get_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27*)
 
+(*val _get_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27*)
+
 (*val _set_SV39_Vaddr_VPNi : register_ref regstate register_value SV39_Vaddr -> mword ty27 -> M unit*)
 
 (*val _set_SV48_Vaddr_VPNi : register_ref regstate register_value SV48_Vaddr -> mword ty27 -> M unit*)
+
+(*val _set_SV57_Vaddr_VPNi : register_ref regstate register_value SV57_Vaddr -> mword ty27 -> M unit*)
 
 (*val _get_SV32_Vaddr_PgOfs : SV32_Vaddr -> mword ty12*)
 
@@ -16440,6 +16465,10 @@ val _ = Define `
 
 (*val _update_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12 -> SV48_Vaddr*)
 
+(*val _update_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12 -> SV57_Paddr*)
+
+(*val _update_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12 -> SV57_Vaddr*)
+
 (*val _get_SV32_Paddr_PgOfs : SV32_Paddr -> mword ty12*)
 
 (*val _get_SV39_Paddr_PgOfs : SV39_Paddr -> mword ty12*)
@@ -16450,6 +16479,10 @@ val _ = Define `
 
 (*val _get_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12*)
 
+(*val _get_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12*)
+
+(*val _get_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12*)
+
 (*val _set_SV32_Paddr_PgOfs : register_ref regstate register_value SV32_Paddr -> mword ty12 -> M unit*)
 
 (*val _set_SV39_Paddr_PgOfs : register_ref regstate register_value SV39_Paddr -> mword ty12 -> M unit*)
@@ -16459,6 +16492,10 @@ val _ = Define `
 (*val _set_SV48_Paddr_PgOfs : register_ref regstate register_value SV48_Paddr -> mword ty12 -> M unit*)
 
 (*val _set_SV48_Vaddr_PgOfs : register_ref regstate register_value SV48_Vaddr -> mword ty12 -> M unit*)
+
+(*val _set_SV57_Paddr_PgOfs : register_ref regstate register_value SV57_Paddr -> mword ty12 -> M unit*)
+
+(*val _set_SV57_Vaddr_PgOfs : register_ref regstate register_value SV57_Vaddr -> mword ty12 -> M unit*)
 
 (*val Mk_SV32_Paddr : mword ty34 -> SV32_Paddr*)
 
@@ -16535,6 +16572,10 @@ val _ = Define `
 
 (*val _update_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44 -> SV48_Paddr*)
 
+(*val _update_SV57_PTE_PPNi : SV57_PTE -> mword ty44 -> SV57_PTE*)
+
+(*val _update_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44 -> SV57_Paddr*)
+
 (*val _get_SV32_PTE_PPNi : SV32_PTE -> mword ty22*)
 
 (*val _get_SV39_PTE_PPNi : SV39_PTE -> mword ty44*)
@@ -16545,6 +16586,10 @@ val _ = Define `
 
 (*val _get_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44*)
 
+(*val _get_SV57_PTE_PPNi : SV57_PTE -> mword ty44*)
+
+(*val _get_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44*)
+
 (*val _set_SV32_PTE_PPNi : register_ref regstate register_value SV32_PTE -> mword ty22 -> M unit*)
 
 (*val _set_SV39_PTE_PPNi : register_ref regstate register_value SV39_PTE -> mword ty44 -> M unit*)
@@ -16554,6 +16599,10 @@ val _ = Define `
 (*val _set_SV48_PTE_PPNi : register_ref regstate register_value SV48_PTE -> mword ty44 -> M unit*)
 
 (*val _set_SV48_Paddr_PPNi : register_ref regstate register_value SV48_Paddr -> mword ty44 -> M unit*)
+
+(*val _set_SV57_PTE_PPNi : register_ref regstate register_value SV57_PTE -> mword ty44 -> M unit*)
+
+(*val _set_SV57_Paddr_PPNi : register_ref regstate register_value SV57_Paddr -> mword ty44 -> M unit*)
 
 val _ = Define `
  ((get_SV32_Paddr_PgOfs:SV32_Paddr ->(12)words$word) v=
@@ -16675,13 +16724,19 @@ val _ = Define `
 
 (*val _update_SV48_PTE_RSW : SV48_PTE -> mword ty2 -> SV48_PTE*)
 
+(*val _update_SV57_PTE_RSW : SV57_PTE -> mword ty2 -> SV57_PTE*)
+
 (*val _get_SV39_PTE_RSW : SV39_PTE -> mword ty2*)
 
 (*val _get_SV48_PTE_RSW : SV48_PTE -> mword ty2*)
 
+(*val _get_SV57_PTE_RSW : SV57_PTE -> mword ty2*)
+
 (*val _set_SV39_PTE_RSW : register_ref regstate register_value SV39_PTE -> mword ty2 -> M unit*)
 
 (*val _set_SV48_PTE_RSW : register_ref regstate register_value SV48_PTE -> mword ty2 -> M unit*)
+
+(*val _set_SV57_PTE_RSW : register_ref regstate register_value SV57_PTE -> mword ty2 -> M unit*)
 
 (*val _get_SV32_PTE_BITS : SV32_PTE -> mword ty8*)
 
@@ -16718,13 +16773,19 @@ val _ = Define `
 
 (*val _update_SV48_PTE_BITS : SV48_PTE -> mword ty8 -> SV48_PTE*)
 
+(*val _update_SV57_PTE_BITS : SV57_PTE -> mword ty8 -> SV57_PTE*)
+
 (*val _get_SV39_PTE_BITS : SV39_PTE -> mword ty8*)
 
 (*val _get_SV48_PTE_BITS : SV48_PTE -> mword ty8*)
 
+(*val _get_SV57_PTE_BITS : SV57_PTE -> mword ty8*)
+
 (*val _set_SV39_PTE_BITS : register_ref regstate register_value SV39_PTE -> mword ty8 -> M unit*)
 
 (*val _set_SV48_PTE_BITS : register_ref regstate register_value SV48_PTE -> mword ty8 -> M unit*)
+
+(*val _set_SV57_PTE_BITS : register_ref regstate register_value SV57_PTE -> mword ty8 -> M unit*)
 
 (*val curAsid64 : mword ty64 -> mword ty16*)
 
@@ -17320,6 +17381,11 @@ val _ = Define `
            ((subrange_vec_dec x (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
           :  64 words$word)) |>)))`;
 
+(*val _update_SV57_PTE_Ext : SV57_PTE -> mword ty10 -> SV57_PTE*)
+
+(*val _get_SV57_PTE_Ext : SV57_PTE -> mword ty10*)
+
+(*val _set_SV57_PTE_Ext : register_ref regstate register_value SV57_PTE -> mword ty10 -> M unit*)
 
 val _ = Define `
  ((get_SV48_PTE_PPNi:SV48_PTE ->(44)words$word) v=
@@ -17396,6 +17462,325 @@ val _ = Define `
            ((subrange_vec_dec x (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
           :  64 words$word)) |>)))`;
 
+val _ = Define `
+((SV57_LEVEL_BITS:int)=  ((( 9 : int):ii)))`;
+
+
+val _ = Define `
+((SV57_LEVELS:int)=  ((( 5 : int):ii)))`;
+
+
+val _ = Define `
+((PTE57_LOG_SIZE:int)=  ((( 3 : int):ii)))`;
+
+
+val _ = Define `
+((PTE57_SIZE:int)=  ((( 8 : int):ii)))`;
+
+
+(*val Mk_SV57_Vaddr : mword ty57 -> SV57_Vaddr*)
+
+val _ = Define `
+ ((Mk_SV57_Vaddr:(57)words$word -> SV57_Vaddr) v=
+    (<| SV57_Vaddr_SV57_Vaddr_chunk_0 := ((subrange_vec_dec v (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_bits:SV57_Vaddr ->(57)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_bits:((regstate),(register_value),(SV57_Vaddr))register_ref ->(57)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_bits:SV57_Vaddr ->(57)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 56 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word))
+          :  57 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_VPNi:SV57_Vaddr ->(27)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)  :  27 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_VPNi:((regstate),(register_value),(SV57_Vaddr))register_ref ->(27)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)
+             ((subrange_vec_dec v (( 26 : int):ii) (( 0 : int):ii)  :  27 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_VPNi:SV57_Vaddr ->(27)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 38 : int):ii) (( 12 : int):ii)
+           ((subrange_vec_dec x (( 26 : int):ii) (( 0 : int):ii)  :  27 words$word))
+          :  57 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Vaddr_PgOfs:SV57_Vaddr ->(12)words$word) v=
+    ((subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Vaddr_PgOfs:((regstate),(register_value),(SV57_Vaddr))register_ref ->(12)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+            :  57 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Vaddr_PgOfs:SV57_Vaddr ->(12)words$word -> SV57_Vaddr) v x=
+    (( v with<|
+     SV57_Vaddr_SV57_Vaddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Vaddr_SV57_Vaddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+          :  57 words$word)) |>)))`;
+
+
+(*val Mk_SV57_Paddr : mword ty56 -> SV57_Paddr*)
+
+val _ = Define `
+ ((Mk_SV57_Paddr:(56)words$word -> SV57_Paddr) v=
+    (<| SV57_Paddr_SV57_Paddr_chunk_0 := ((subrange_vec_dec v (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_bits:SV57_Paddr ->(56)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_bits:((regstate),(register_value),(SV57_Paddr))register_ref ->(56)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_bits:SV57_Paddr ->(56)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 55 : int):ii) (( 0 : int):ii)  :  56 words$word))
+          :  56 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_PPNi:SV57_Paddr ->(44)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)  :  44 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_PPNi:((regstate),(register_value),(SV57_Paddr))register_ref ->(44)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)
+             ((subrange_vec_dec v (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_PPNi:SV57_Paddr ->(44)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 55 : int):ii) (( 12 : int):ii)
+           ((subrange_vec_dec x (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+          :  56 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_Paddr_PgOfs:SV57_Paddr ->(12)words$word) v=
+    ((subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_Paddr_PgOfs:((regstate),(register_value),(SV57_Paddr))register_ref ->(12)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_Paddr_SV57_Paddr_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+            :  56 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_Paddr_PgOfs:SV57_Paddr ->(12)words$word -> SV57_Paddr) v x=
+    (( v with<|
+     SV57_Paddr_SV57_Paddr_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_Paddr_SV57_Paddr_chunk_0 (( 11 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 11 : int):ii) (( 0 : int):ii)  :  12 words$word))
+          :  56 words$word)) |>)))`;
+
+
+(*val Mk_SV57_PTE : mword ty64 -> SV57_PTE*)
+
+val _ = Define `
+ ((Mk_SV57_PTE:(64)words$word -> SV57_PTE) v=
+    (<| SV57_PTE_SV57_PTE_chunk_0 := ((subrange_vec_dec v (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word)) |>))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_bits:SV57_PTE ->(64)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_bits:((regstate),(register_value),(SV57_PTE))register_ref ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_bits:SV57_PTE ->(64)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 63 : int):ii) (( 0 : int):ii)  :  64 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_Ext:SV57_PTE ->(10)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)  :  10 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_Ext:((regstate),(register_value),(SV57_PTE))register_ref ->(10)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)
+             ((subrange_vec_dec v (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_Ext:SV57_PTE ->(10)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 63 : int):ii) (( 54 : int):ii)
+           ((subrange_vec_dec x (( 9 : int):ii) (( 0 : int):ii)  :  10 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_PPNi:SV57_PTE ->(44)words$word) v=
+    ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)  :  44 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_PPNi:((regstate),(register_value),(SV57_PTE))register_ref ->(44)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)
+             ((subrange_vec_dec v (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_PPNi:SV57_PTE ->(44)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 53 : int):ii) (( 10 : int):ii)
+           ((subrange_vec_dec x (( 43 : int):ii) (( 0 : int):ii)  :  44 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_RSW:SV57_PTE ->(2)words$word) v=  ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)  :  2 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_RSW:((regstate),(register_value),(SV57_PTE))register_ref ->(2)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)
+             ((subrange_vec_dec v (( 1 : int):ii) (( 0 : int):ii)  :  2 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_RSW:SV57_PTE ->(2)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 9 : int):ii) (( 8 : int):ii)
+           ((subrange_vec_dec x (( 1 : int):ii) (( 0 : int):ii)  :  2 words$word))
+          :  64 words$word)) |>)))`;
+
+
+val _ = Define `
+ ((get_SV57_PTE_BITS:SV57_PTE ->(8)words$word) v=  ((subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word)))`;
+
+
+val _ = Define `
+ ((set_SV57_PTE_BITS:((regstate),(register_value),(SV57_PTE))register_ref ->(8)words$word ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) r_ref v=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS r_ref) (\ r . 
+   let r =
+     (( r with<|
+       SV57_PTE_SV57_PTE_chunk_0 :=
+         ((update_subrange_vec_dec r.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)
+             ((subrange_vec_dec v (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
+            :  64 words$word)) |>)) in
+   sail2_state_monad$write_regS r_ref r)))`;
+
+
+val _ = Define `
+ ((update_SV57_PTE_BITS:SV57_PTE ->(8)words$word -> SV57_PTE) v x=
+    (( v with<|
+     SV57_PTE_SV57_PTE_chunk_0 :=
+       ((update_subrange_vec_dec v.SV57_PTE_SV57_PTE_chunk_0 (( 7 : int):ii) (( 0 : int):ii)
+           ((subrange_vec_dec x (( 7 : int):ii) (( 0 : int):ii)  :  8 words$word))
+          :  64 words$word)) |>)))`;
 
 (*val make_TLB_Entry : forall 'asidlen 'palen 'ptelen 'valen. Size 'asidlen, Size 'palen, Size 'ptelen, Size 'valen => mword 'asidlen -> bool -> mword 'valen -> mword 'palen -> mword 'ptelen -> ii -> mword 'palen -> ii -> M (TLB_Entry 'asidlen 'valen 'palen 'ptelen)*)
 
@@ -17815,6 +18200,168 @@ val _ = Define `
 val _ = Define `
  ((init_vmem_sv48:unit ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) () =  (sail2_state_monad$write_regS tlb48_ref NONE))`;
 
+(*val walk57 : mword ty57 -> AccessType unit -> Privilege -> bool -> bool -> mword ty56 -> ii -> bool -> unit -> M (PTW_Result (mword ty56) SV57_PTE)*)
+
+ val walk57_defn = Hol_defn "walk57" `
+ ((walk57:(57)words$word ->(unit)AccessType -> Privilege -> bool -> bool ->(56)words$word -> int -> bool -> unit ->(regstate)sail2_state_monad$sequential_state ->((((((56)words$word),(SV57_PTE))PTW_Result),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) vaddr ac priv mxr do_sum ptb level global ext_ptw=
+    (let va = (Mk_SV57_Vaddr vaddr) in
+   let (pt_ofs : paddr64) =
+     ((shiftl
+        ((EXTZ (( 56 : int):ii)
+            ((subrange_vec_dec
+                ((shiftr ((get_SV57_Vaddr_VPNi va  :  27 words$word))
+                    ((level * SV57_LEVEL_BITS))
+                   :  27 words$word)) ((SV57_LEVEL_BITS - (( 1 : int):ii))) (( 0 : int):ii)
+               :  9 words$word))
+           :  56 words$word)) PTE57_LOG_SIZE
+       :  56 words$word)) in
+   let pte_addr = ((add_vec ptb pt_ofs  :  56 words$word)) in sail2_state_monad$bindS
+   (mem_read_priv (Read Data) Supervisor ((EXTZ (( 64 : int):ii) pte_addr  :  64 words$word)) (( 8 : int):ii) F F
+      F
+     : ( ( 64 words$word)MemoryOpResult) M) (\ (w__0 : ( 64 words$word) MemoryOpResult) . 
+   (case w__0 of
+     MemException (_) => sail2_state_monad$returnS (PTW_Failure (PTW_Access () , ext_ptw))
+   | MemValue (v) =>
+      let pte = (Mk_SV57_PTE v) in
+      let pbits = ((get_SV57_PTE_BITS pte  :  8 words$word)) in
+      let ext_pte = ((get_SV57_PTE_Ext pte  :  10 words$word)) in
+      let pattr = (Mk_PTE_Bits pbits) in
+      let is_global =
+        (global \/ (((((get_PTE_Bits_G pattr  :  1 words$word)) = (0b1w :  1 words$word))))) in
+      if ((isInvalidPTE pbits ext_pte)) then sail2_state_monad$returnS (PTW_Failure (PTW_Invalid_PTE () , ext_ptw))
+      else if ((isPTEPtr pbits ext_pte)) then
+        if ((level > (( 0 : int):ii))) then
+          (walk57 vaddr ac priv mxr do_sum
+             ((shiftl ((EXTZ (( 56 : int):ii) ((get_SV57_PTE_PPNi pte  :  44 words$word))  :  56 words$word))
+                 PAGESIZE_BITS
+                :  56 words$word)) ((level - (( 1 : int):ii))) is_global ext_ptw
+            : ( (( 56 words$word), SV57_PTE)PTW_Result) M)
+        else sail2_state_monad$returnS (PTW_Failure (PTW_Invalid_PTE () , ext_ptw))
+      else sail2_state_monad$bindS
+        (checkPTEPermission ac priv mxr do_sum pattr ext_pte ext_ptw) (\ (w__3 : PTE_Check) . 
+        sail2_state_monad$returnS ((case w__3 of
+          PTE_Check_Failure ((ext_ptw, ext_ptw_fail)) =>
+           PTW_Failure (ext_get_ptw_error ext_ptw_fail, ext_ptw)
+        | PTE_Check_Success (ext_ptw) =>
+           if ((level > (( 0 : int):ii))) then
+             let mask =
+               ((sub_vec_int
+                  ((shiftl
+                      ((xor_vec ((get_SV57_PTE_PPNi pte  :  44 words$word))
+                          ((xor_vec ((get_SV57_PTE_PPNi pte  :  44 words$word))
+                              ((EXTZ (( 44 : int):ii) (0b1w :  1 words$word)  :  44 words$word))
+                             :  44 words$word))
+                         :  44 words$word)) ((level * SV57_LEVEL_BITS))
+                     :  44 words$word)) (( 1 : int):ii)
+                 :  44 words$word)) in
+             if (((((and_vec ((get_SV57_PTE_PPNi pte  :  44 words$word)) mask  :  44 words$word)) <> ((EXTZ (( 44 : int):ii) (0b0w :  1 words$word)  :  44 words$word))))) then
+               PTW_Failure (PTW_Misaligned () , ext_ptw)
+             else
+               let ppn =
+                 ((or_vec ((get_SV57_PTE_PPNi pte  :  44 words$word))
+                    ((and_vec
+                        ((EXTZ (( 44 : int):ii) ((get_SV57_Vaddr_VPNi va  :  27 words$word))  :  44 words$word))
+                        mask
+                       :  44 words$word))
+                   :  44 words$word)) in
+               PTW_Success ((concat_vec ppn ((get_SV57_Vaddr_PgOfs va  :  12 words$word))  :  56 words$word),
+                            pte,
+                            pte_addr,
+                            level,
+                            is_global,
+                            ext_ptw)
+           else
+             PTW_Success ((concat_vec ((get_SV57_PTE_PPNi pte  :  44 words$word))
+                             ((get_SV57_Vaddr_PgOfs va  :  12 words$word))
+                            :  56 words$word),
+                          pte,
+                          pte_addr,
+                          level,
+                          is_global,
+                          ext_ptw)
+        )))
+   ))))`;
+
+val _ = Lib.with_flag (computeLib.auto_import_definitions, false) Defn.save_defn walk57_defn;
+
+(*val lookup_TLB57 : mword ty16 -> mword ty57 -> M (maybe ((ii * TLB_Entry ty16 ty57 ty56 ty64)))*)
+
+val _ = Define `
+ ((lookup_TLB57:(16)words$word ->(57)words$word ->(regstate)sail2_state_monad$sequential_state ->((((int#((16),(57),(56),(64))TLB_Entry)option),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) asid vaddr=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS tlb57_ref) (\ (w__0 :  ( (16, 57, 56, 64)TLB_Entry)option) . 
+   sail2_state_monad$returnS ((case w__0 of
+     NONE => NONE
+   | SOME (e) => if ((match_TLB_Entry e asid vaddr)) then SOME ((( 0 : int):ii), e) else NONE
+   )))))`;
+
+
+(*val add_to_TLB57 : mword ty16 -> mword ty57 -> mword ty56 -> SV57_PTE -> mword ty56 -> ii -> bool -> M unit*)
+
+val _ = Define `
+ ((add_to_TLB57:(16)words$word ->(57)words$word ->(56)words$word -> SV57_PTE ->(56)words$word -> int -> bool ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) asid vAddr pAddr pte pteAddr level global=  (sail2_state_monad$bindS
+   (make_TLB_Entry asid global vAddr pAddr ((get_SV57_PTE_bits pte  :  64 words$word)) level pteAddr
+     SV57_LEVEL_BITS) (\ (ent : TLB57_Entry) . 
+   sail2_state_monad$write_regS tlb57_ref (SOME ent))))`;
+
+
+(*val write_TLB57 : ii -> TLB_Entry ty16 ty57 ty56 ty64 -> M unit*)
+
+val _ = Define `
+ ((write_TLB57:int ->((16),(57),(56),(64))TLB_Entry ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) (idx : ii) (ent : TLB57_Entry)=  (sail2_state_monad$write_regS tlb57_ref (SOME ent)))`;
+
+
+(*val flush_TLB57 : maybe (mword ty16) -> maybe (mword ty57) -> M unit*)
+
+val _ = Define `
+ ((flush_TLB57:((16)words$word)option ->((57)words$word)option ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) asid addr=  (sail2_state_monad$bindS
+   (sail2_state_monad$read_regS tlb57_ref) (\ (w__0 :  ( (16, 57, 56, 64)TLB_Entry)option) . 
+   (case w__0 of
+     NONE => sail2_state_monad$returnS () 
+   | SOME (e) => if ((flush_TLB_Entry e asid addr)) then sail2_state_monad$write_regS tlb57_ref NONE else sail2_state_monad$returnS () 
+   ))))`;
+
+
+(*val translate57 : mword ty16 -> mword ty56 -> mword ty57 -> AccessType unit -> Privilege -> bool -> bool -> ii -> unit -> M (TR_Result (mword ty56) PTW_Error)*)
+
+val _ = Define `
+ ((translate57:(16)words$word ->(56)words$word ->(57)words$word ->(unit)AccessType -> Privilege -> bool -> bool -> int -> unit ->(regstate)sail2_state_monad$sequential_state ->((((((56)words$word),(PTW_Error))TR_Result),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) asid ptb vAddr ac priv mxr do_sum level ext_ptw=  (sail2_state_monad$bindS
+   (walk57 vAddr ac priv mxr do_sum ptb level F ext_ptw  : ( (( 56 words$word), SV57_PTE)PTW_Result) M) (\ (w__0 : (( 56 words$word), SV57_PTE)
+     PTW_Result) . 
+   (case w__0 of
+     PTW_Failure ((f, ext_ptw)) => sail2_state_monad$returnS (TR_Failure (f, ext_ptw))
+   | PTW_Success ((pAddr, pte, pteAddr, level, global, ext_ptw)) =>
+      (case ((update_PTE_Bits ((Mk_PTE_Bits ((get_SV57_PTE_BITS pte  :  8 words$word)))) ac
+                ((get_SV57_PTE_Ext pte  :  10 words$word))
+               :  ((PTE_Bits #  10 words$word))option)) of
+        NONE => sail2_state_monad$seqS
+         (add_to_TLB57 asid vAddr pAddr pte pteAddr level global)
+         (sail2_state_monad$returnS (TR_Address (pAddr, ext_ptw)))
+      | SOME ((pbits, ext)) =>
+         if ((~ ((plat_enable_dirty_update () )))) then
+           sail2_state_monad$returnS (TR_Failure (PTW_PTE_Update () , ext_ptw))
+         else
+           let (w_pte : SV57_PTE) =
+             (update_SV57_PTE_BITS pte ((get_PTE_Bits_bits pbits  :  8 words$word))) in
+           let (w_pte : SV57_PTE) = (update_SV57_PTE_Ext w_pte ext) in sail2_state_monad$bindS
+           (mem_write_value_priv ((EXTZ (( 64 : int):ii) pteAddr  :  64 words$word)) (( 8 : int):ii)
+             ((get_SV57_PTE_bits w_pte  :  64 words$word)) Supervisor F F F) (\ (w__1 : bool
+             MemoryOpResult) . 
+           (case w__1 of
+             MemValue (_) => sail2_state_monad$seqS
+              (add_to_TLB57 asid vAddr pAddr w_pte pteAddr level global)
+              (sail2_state_monad$returnS (TR_Address (pAddr, ext_ptw)))
+           | MemException (e) => sail2_state_monad$returnS (TR_Failure (PTW_Access () , ext_ptw))
+           ))
+      )
+   ))))`;
+
+
+(*val init_vmem_sv57 : unit -> M unit*)
+
+val _ = Define `
+ ((init_vmem_sv57:unit ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) () =  (sail2_state_monad$write_regS tlb57_ref NONE))`;
+
+
 
 (*val legalize_satp : Architecture -> mword ty64 -> mword ty64 -> mword ty64*)
 
@@ -17840,6 +18387,13 @@ val _ = Define `
         (ones (((((( 63 : int):ii) - (( 48 : int):ii))) + (( 1 : int):ii)))  :  16 words$word)
       else (zeros_implicit (((((( 63 : int):ii) - (( 48 : int):ii))) + (( 1 : int):ii)))  :  16 words$word))))`;
 
+(*val isValidSv57Addr : mword ty64 -> bool*)
+
+val _ = Define `
+ ((isValidSv57Addr:(64)words$word -> bool) vAddr=
+    (((subrange_vec_dec vAddr (( 63 : int):ii) (( 57 : int):ii)  :  16 words$word)) = (if (((((access_vec_dec vAddr (( 56 : int):ii))) = B1))) then
+        (ones (((((( 63 : int):ii) - (( 57 : int):ii))) + (( 1 : int):ii)))  :  16 words$word)
+      else (zeros_implicit (((((( 63 : int):ii) - (( 57 : int):ii))) + (( 1 : int):ii)))  :  16 words$word))))`;
 
 (*val translationMode : Privilege -> M SATPMode*)
 
@@ -17902,6 +18456,16 @@ val _ = Define `
         | TR_Failure ((f, ext_ptw)) => TR_Failure (translationException ac f, ext_ptw)
         )))
       else sail2_state_monad$returnS (TR_Failure (translationException ac (PTW_Invalid_Addr () ), ext_ptw))
+   | Sv57 =>
+      if ((isValidSv57Addr vAddr)) then sail2_state_monad$bindS
+        (translate57 asid ptb ((subrange_vec_dec vAddr (( 56 : int):ii) (( 0 : int):ii)  :  57 words$word)) ac effPriv mxr
+           do_sum ((SV57_LEVELS - (( 1 : int):ii))) ext_ptw
+          : ( (( 56 words$word), PTW_Error)TR_Result) M) (\ (w__6 : (( 56 words$word), PTW_Error) TR_Result) . 
+        sail2_state_monad$returnS ((case w__6 of
+          TR_Address ((pa, ext_ptw)) => TR_Address ((EXTZ (( 64 : int):ii) pa  :  64 words$word), ext_ptw)
+        | TR_Failure ((f, ext_ptw)) => TR_Failure (translationException ac f, ext_ptw)
+        )))
+      else sail2_state_monad$returnS (TR_Failure (translationException ac (PTW_Invalid_Addr () ), ext_ptw))
    | _ =>
       (internal_error "unsupported address translation scheme"
         : ( (( 64 words$word), ExceptionType)TR_Result) M)
@@ -17940,7 +18504,7 @@ val _ = Define `
 (*val init_vmem : unit -> M unit*)
 
 val _ = Define `
- ((init_vmem:unit ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) () =  (sail2_state_monad$seqS (init_vmem_sv39 () ) (init_vmem_sv48 () )))`;
+ ((init_vmem:unit ->(regstate)sail2_state_monad$sequential_state ->(((unit),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) () =  (sail2_state_monad$seqS (init_vmem_sv39 () ) (init_vmem_sv48 () ) (init_vmem_sv57 () )))`;
 
 
 (*val execute : ast -> M Retired*)

--- a/prover_snapshots/hol4/RV64/riscv_typesScript.sml
+++ b/prover_snapshots/hol4/RV64/riscv_typesScript.sml
@@ -477,7 +477,7 @@ val _ = Hol_datatype `
 val _ = type_abbrev( "satp_mode"  , ``: 4 bits``);
 
 val _ = Hol_datatype `
- SATPMode =   Sbare | Sv32 | Sv39 | Sv48`;
+ SATPMode =   Sbare | Sv32 | Sv39 | Sv48 | Sv57`;
 
 
 
@@ -592,6 +592,21 @@ val _ = Hol_datatype `
 
 val _ = Hol_datatype `
  SV48_Vaddr  = <| SV48_Vaddr_SV48_Vaddr_chunk_0 :  48 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_PTE  = <| SV57_PTE_SV57_PTE_chunk_0 :  64 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_Paddr  = <| SV57_Paddr_SV57_Paddr_chunk_0 :  56 words$word  |>`;
+
+
+
+val _ = Hol_datatype `
+ SV57_Vaddr  = <| SV57_Vaddr_SV57_Vaddr_chunk_0 :  57 words$word  |>`;
 
 
 
@@ -759,7 +774,11 @@ val _ = type_abbrev( "vaddr39"  , ``: 39 bits``);
 
 val _ = type_abbrev( "vaddr48"  , ``: 48 bits``);
 
+val _ = type_abbrev( "vaddr57"  , ``: 57 bits``);
+
 val _ = type_abbrev( "pte48"  , ``: 64 bits``);
+
+val _ = type_abbrev( "pte57"  , ``: 64 bits``);
 
 val _ = Hol_datatype `
  PTW_Result =
@@ -794,6 +813,8 @@ val _ = type_abbrev( "TLB39_Entry"  , ``: (16, 39, 56, 64) TLB_Entry``);
 
 val _ = type_abbrev( "TLB48_Entry"  , ``: (16, 48, 56, 64) TLB_Entry``);
 
+val _ = type_abbrev( "TLB57_Entry"  , ``: (16, 57, 56, 64) TLB_Entry``);
+
 val _ = Hol_datatype `
  FetchResult  =
     F_Ext_Error of (ext_fetch_addr_error)
@@ -825,6 +846,7 @@ val _ = Hol_datatype `
   | Regval_Sinterrupts of (Sinterrupts)
   | Regval_TLB_Entry_16_39_56_64 of ( (16, 39, 56, 64)TLB_Entry)
   | Regval_TLB_Entry_16_48_56_64 of ( (16, 48, 56, 64)TLB_Entry)
+  | Regval_TLB_Entry_16_57_56_64 of ( (16, 57, 56, 64)TLB_Entry)
   | Regval_bit of (bitU)
   | Regval_bitvector_32_dec of ( 32 words$word)
   | Regval_bitvector_4_dec of ( 4 words$word)
@@ -856,7 +878,8 @@ val _ = Hol_datatype `
      bitvector_64_dec_reg : string ->  64 words$word;
      bool_reg : string -> bool;
      option_TLB_Entry_16_39_56_64_reg : string ->  ( (16, 39, 56, 64)TLB_Entry)option;
-     option_TLB_Entry_16_48_56_64_reg : string ->  ( (16, 48, 56, 64)TLB_Entry)option  |>`;
+     option_TLB_Entry_16_48_56_64_reg : string ->  ( (16, 48, 56, 64)TLB_Entry)option;
+     option_TLB_Entry_16_57_56_64_reg : string ->  ( (16, 57, 56, 64)TLB_Entry)option  |>`;
 
 
 
@@ -1066,6 +1089,18 @@ val _ = Define `
 val _ = Define `
  ((regval_of_TLB_Entry_16_48_56_64:((16),(48),(56),(64))TLB_Entry -> register_value) v=  (Regval_TLB_Entry_16_48_56_64 v))`;
 
+(*val TLB_Entry_16_57_56_64_of_regval : register_value -> maybe (TLB_Entry ty16 ty57 ty56 ty64)*)
+
+val _ = Define `
+ ((TLB_Entry_16_57_56_64_of_regval:register_value ->(((16),(57),(56),(64))TLB_Entry)option) merge_var=
+    ((case merge_var of   Regval_TLB_Entry_16_57_56_64 (v) => SOME v | _ => NONE )))`;
+
+
+(*val regval_of_TLB_Entry_16_57_56_64 : TLB_Entry ty16 ty57 ty56 ty64 -> register_value*)
+
+val _ = Define `
+ ((regval_of_TLB_Entry_16_57_56_64:((16),(57),(56),(64))TLB_Entry -> register_value) v=  (Regval_TLB_Entry_16_57_56_64 v))`;
+
 
 (*val bit_of_regval : register_value -> maybe bitU*)
 
@@ -1184,6 +1219,14 @@ val _ = Define `
   of_regval := (\ v .  bitvector_64_dec_of_regval v);
   regval_of := (\ v .  regval_of_bitvector_64_dec v) |>))`;
 
+val _ = Define `
+ ((tlb57_ref:((regstate),(register_value),((((16),(57),(56),(64))TLB_Entry)option))register_ref)=  (<|
+  name := "tlb57";
+  read_from := (\ s .  s.option_TLB_Entry_16_57_56_64_reg "tlb57");
+  write_to := (\ v s .  (( s with<| option_TLB_Entry_16_57_56_64_reg :=
+  (\ reg .  if reg = "tlb57" then v else s.option_TLB_Entry_16_57_56_64_reg reg) |>)));
+  of_regval := (\ v .  option_of_regval (\ v .  TLB_Entry_16_57_56_64_of_regval v) v);
+  regval_of := (\ v .  regval_of_option (\ v .  regval_of_TLB_Entry_16_57_56_64 v) v) |>))`;
 
 val _ = Define `
  ((tlb48_ref:((regstate),(register_value),((((16),(48),(56),(64))TLB_Entry)option))register_ref)=  (<|
@@ -2659,6 +2702,7 @@ val _ = Define `
 val _ = Define `
  ((get_regval:string -> regstate ->(register_value)option) reg_name s=
    (if reg_name = "satp" then SOME (satp_ref.regval_of (satp_ref.read_from s)) else
+  if reg_name = "tlb57" then SOME (tlb57_ref.regval_of (tlb57_ref.read_from s)) else
   if reg_name = "tlb48" then SOME (tlb48_ref.regval_of (tlb48_ref.read_from s)) else
   if reg_name = "tlb39" then SOME (tlb39_ref.regval_of (tlb39_ref.read_from s)) else
   if reg_name = "htif_payload_writes" then SOME (htif_payload_writes_ref.regval_of (htif_payload_writes_ref.read_from s)) else
@@ -2813,6 +2857,7 @@ val _ = Define `
 val _ = Define `
  ((set_regval:string -> register_value -> regstate ->(regstate)option) reg_name v s=
    (if reg_name = "satp" then OPTION_MAP (\ v .  satp_ref.write_to v s) (satp_ref.of_regval v) else
+  if reg_name = "tlb57" then OPTION_MAP (\ v .  tlb57_ref.write_to v s) (tlb57_ref.of_regval v) else
   if reg_name = "tlb48" then OPTION_MAP (\ v .  tlb48_ref.write_to v s) (tlb48_ref.of_regval v) else
   if reg_name = "tlb39" then OPTION_MAP (\ v .  tlb39_ref.write_to v s) (tlb39_ref.of_regval v) else
   if reg_name = "htif_payload_writes" then OPTION_MAP (\ v .  htif_payload_writes_ref.write_to v s) (htif_payload_writes_ref.of_regval v) else

--- a/prover_snapshots/isabelle/RV32/Riscv.thy
+++ b/prover_snapshots/isabelle/RV32/Riscv.thy
@@ -2402,7 +2402,8 @@ definition SATPMode_of_num  :: \<open> int \<Rightarrow> SATPMode \<close>  wher
    if (((l__247 = (( 0 :: int)::ii)))) then Sbare
    else if (((l__247 = (( 1 :: int)::ii)))) then Sv32
    else if (((l__247 = (( 2 :: int)::ii)))) then Sv39
-   else Sv48))\<close> 
+   else if (((l__247 = (( 3 :: int)::ii)))) then Sv48
+   else Sv57))\<close> 
   for  arg1  :: " int "
 
 
@@ -2413,6 +2414,7 @@ fun num_of_SATPMode  :: \<open> SATPMode \<Rightarrow> int \<close>  where
 |\<open> num_of_SATPMode Sv32 = ( (( 1 :: int)::ii))\<close>
 |\<open> num_of_SATPMode Sv39 = ( (( 2 :: int)::ii))\<close>
 |\<open> num_of_SATPMode Sv48 = ( (( 3 :: int)::ii))\<close>
+|\<open> num_of_SATPMode Sv57 = ( (( 4 :: int)::ii))\<close>
 
 
 \<comment> \<open>\<open>val satp64Mode_of_bits : Architecture -> mword ty4 -> maybe SATPMode\<close>\<close>
@@ -2428,6 +2430,7 @@ definition satp64Mode_of_bits  :: \<open> Architecture \<Rightarrow>(4)Word.word
         | (RV64, b__0) =>
            if (((b__0 = ( 0x8 ::  4 Word.word)))) then Some Sv39
            else if (((b__0 = ( 0x9 ::  4 Word.word)))) then Some Sv48
+           else if (((b__0 = ( 0xA ::  4 Word.word)))) then Some Sv57
            else (case  (RV64, b__0) of   (_, _) => None )
         | (_, _) => None
         ))\<close> 
@@ -4584,6 +4587,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(32)Word.word \<Righta
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_bits : SV57_PTE -> mword ty64 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Paddr_bits : SV57_Paddr -> mword ty56 -> SV57_Paddr\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _update_Satp32_bits : Satp32 -> mword ty32 -> Satp32\<close>\<close>
 
 \<comment> \<open>\<open>val _update_Satp64_bits : Satp64 -> mword ty64 -> Satp64\<close>\<close>
@@ -4640,6 +4649,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(32)Word.word \<Righta
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_bits : SV57_PTE -> mword ty64\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Paddr_bits : SV57_Paddr -> mword ty56\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57\<close>\<close>
+
 \<comment> \<open>\<open>val _get_Satp32_bits : Satp32 -> mword ty32\<close>\<close>
 
 \<comment> \<open>\<open>val _get_Satp64_bits : Satp64 -> mword ty64\<close>\<close>
@@ -4695,6 +4710,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(32)Word.word \<Righta
 \<comment> \<open>\<open>val _set_SV48_Paddr_bits : register_ref regstate register_value SV48_Paddr -> mword ty56 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_bits : register_ref regstate register_value SV48_Vaddr -> mword ty48 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_bits : register_ref regstate register_value SV57_PTE -> mword ty64 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_bits : register_ref regstate register_value SV57_Paddr -> mword ty56 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_bits : register_ref regstate register_value SV57_Vaddr -> mword ty57 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_Satp32_bits : register_ref regstate register_value Satp32 -> mword ty32 -> M unit\<close>\<close>
 
@@ -17302,6 +17323,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12 -> SV57_Paddr\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV32_Paddr_PgOfs : SV32_Paddr -> mword ty12\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV39_Paddr_PgOfs : SV39_Paddr -> mword ty12\<close>\<close>
@@ -17312,6 +17337,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV32_Paddr_PgOfs : register_ref regstate register_value SV32_Paddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV39_Paddr_PgOfs : register_ref regstate register_value SV39_Paddr -> mword ty12 -> M unit\<close>\<close>
@@ -17321,6 +17350,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 \<comment> \<open>\<open>val _set_SV48_Paddr_PgOfs : register_ref regstate register_value SV48_Paddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_PgOfs : register_ref regstate register_value SV48_Vaddr -> mword ty12 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_PgOfs : register_ref regstate register_value SV57_Paddr -> mword ty12 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_PgOfs : register_ref regstate register_value SV57_Vaddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV32_Vaddr_VPNi : SV32_Vaddr -> mword ty20\<close>\<close>
 
@@ -17357,13 +17390,19 @@ definition update_SV32_Vaddr_VPNi  :: \<open> SV32_Vaddr \<Rightarrow>(20)Word.w
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_Vaddr_VPNi : SV39_Vaddr -> mword ty27\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_Vaddr_VPNi : register_ref regstate register_value SV39_Vaddr -> mword ty27 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_VPNi : register_ref regstate register_value SV48_Vaddr -> mword ty27 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_VPNi : register_ref regstate register_value SV57_Vaddr -> mword ty27 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val undefined_SV32_Paddr : unit -> M SV32_Paddr\<close>\<close>
 
@@ -17447,6 +17486,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 
 \<comment> \<open>\<open>val _update_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44 -> SV48_Paddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_PPNi : SV57_PTE -> mword ty44 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44 -> SV57_Paddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV32_PTE_PPNi : SV32_PTE -> mword ty22\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV39_PTE_PPNi : SV39_PTE -> mword ty44\<close>\<close>
@@ -17457,6 +17500,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 
 \<comment> \<open>\<open>val _get_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_PPNi : SV57_PTE -> mword ty44\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV32_PTE_PPNi : register_ref regstate register_value SV32_PTE -> mword ty22 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV39_PTE_PPNi : register_ref regstate register_value SV39_PTE -> mword ty44 -> M unit\<close>\<close>
@@ -17466,6 +17513,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 \<comment> \<open>\<open>val _set_SV48_PTE_PPNi : register_ref regstate register_value SV48_PTE -> mword ty44 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Paddr_PPNi : register_ref regstate register_value SV48_Paddr -> mword ty44 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_PPNi : register_ref regstate register_value SV57_PTE -> mword ty44 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_PPNi : register_ref regstate register_value SV57_Paddr -> mword ty44 -> M unit\<close>\<close>
 
 definition get_SV32_Paddr_PgOfs  :: \<open> SV32_Paddr \<Rightarrow>(12)Word.word \<close>  where 
      \<open> get_SV32_Paddr_PgOfs v = ( (subrange_vec_dec(SV32_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
@@ -17566,13 +17617,19 @@ definition update_SV32_PTE_BITS  :: \<open> SV32_PTE \<Rightarrow>(8)Word.word \
 
 \<comment> \<open>\<open>val _update_SV48_PTE_BITS : SV48_PTE -> mword ty8 -> SV48_PTE\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_BITS : SV57_PTE -> mword ty8 -> SV57_PTE\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_PTE_BITS : SV39_PTE -> mword ty8\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_PTE_BITS : SV48_PTE -> mword ty8\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_BITS : SV57_PTE -> mword ty8\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_PTE_BITS : register_ref regstate register_value SV39_PTE -> mword ty8 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_PTE_BITS : register_ref regstate register_value SV48_PTE -> mword ty8 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_BITS : register_ref regstate register_value SV57_PTE -> mword ty8 -> M unit\<close>\<close>
 
 definition get_SV32_PTE_PPNi  :: \<open> SV32_PTE \<Rightarrow>(22)Word.word \<close>  where 
      \<open> get_SV32_PTE_PPNi v = ( (subrange_vec_dec(SV32_PTE_bits   v) (( 31 :: int)::ii) (( 10 :: int)::ii)  ::  22 Word.word))\<close> 
@@ -17632,13 +17689,19 @@ definition update_SV32_PTE_RSW  :: \<open> SV32_PTE \<Rightarrow>(2)Word.word \<
 
 \<comment> \<open>\<open>val _update_SV48_PTE_RSW : SV48_PTE -> mword ty2 -> SV48_PTE\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_RSW : SV57_PTE -> mword ty2 -> SV57_PTE\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_PTE_RSW : SV39_PTE -> mword ty2\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_PTE_RSW : SV48_PTE -> mword ty2\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_RSW : SV57_PTE -> mword ty2\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_PTE_RSW : register_ref regstate register_value SV39_PTE -> mword ty2 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_PTE_RSW : register_ref regstate register_value SV48_PTE -> mword ty2 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_RSW : register_ref regstate register_value SV57_PTE -> mword ty2 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val curAsid64 : mword ty64 -> mword ty16\<close>\<close>
 
@@ -18291,6 +18354,13 @@ definition update_SV48_PTE_Ext  :: \<open> SV48_PTE \<Rightarrow>(10)Word.word \
   and  x  :: "(10)Word.word "
 
 
+\<comment> \<open>\<open>val _update_SV57_PTE_Ext : SV57_PTE -> mword ty10 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_PTE_Ext : SV57_PTE -> mword ty10\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_Ext : register_ref regstate register_value SV57_PTE -> mword ty10 -> M unit\<close>\<close>
+
+
 definition get_SV48_PTE_PPNi  :: \<open> SV48_PTE \<Rightarrow>(44)Word.word \<close>  where 
      \<open> get_SV48_PTE_PPNi v = ( (subrange_vec_dec(SV48_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii)  ::  44 Word.word))\<close> 
   for  v  :: " SV48_PTE "
@@ -18338,6 +18408,338 @@ definition update_SV48_PTE_RSW  :: \<open> SV48_PTE \<Rightarrow>(2)Word.word \<
   for  v  :: " SV48_PTE " 
   and  x  :: "(2)Word.word "
 
+definition SV57_LEVEL_BITS  :: \<open> int \<close>  where 
+     \<open> SV57_LEVEL_BITS = ( (( 9 :: int)::ii))\<close>
+
+
+definition SV57_LEVELS  :: \<open> int \<close>  where 
+     \<open> SV57_LEVELS = ( (( 5 :: int)::ii))\<close>
+
+
+definition PTE57_LOG_SIZE  :: \<open> int \<close>  where 
+     \<open> PTE57_LOG_SIZE = ( (( 3 :: int)::ii))\<close>
+
+
+definition PTE57_SIZE  :: \<open> int \<close>  where 
+     \<open> PTE57_SIZE = ( (( 8 :: int)::ii))\<close>
+
+
+\<comment> \<open>\<open>val undefined_SV57_Vaddr : unit -> M SV57_Vaddr\<close>\<close>
+
+definition undefined_SV57_Vaddr  :: \<open> unit \<Rightarrow>((register_value),(SV57_Vaddr),(exception))monad \<close>  where 
+     \<open> undefined_SV57_Vaddr _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 57 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      57 Word.word) . 
+   return ((| SV57_Vaddr_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_Vaddr : mword ty57 -> SV57_Vaddr\<close>\<close>
+
+definition Mk_SV57_Vaddr  :: \<open>(57)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> Mk_SV57_Vaddr v = ( (| SV57_Vaddr_bits = v |) )\<close> 
+  for  v  :: "(57)Word.word "
+
+
+definition get_SV57_Vaddr_bits  :: \<open> SV57_Vaddr \<Rightarrow>(57)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_bits v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 56 :: int)::ii) (( 0 :: int)::ii)  ::  57 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_bits  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(57)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 56 :: int)::ii) (( 0 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(57)Word.word "
+
+
+definition update_SV57_Vaddr_bits  :: \<open> SV57_Vaddr \<Rightarrow>(57)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_bits v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 56 :: int)::ii) (( 0 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(57)Word.word "
+
+
+definition get_SV57_Vaddr_PgOfs  :: \<open> SV57_Vaddr \<Rightarrow>(12)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_PgOfs v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_PgOfs  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(12)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_PgOfs r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 11 :: int)::ii) (( 0 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(12)Word.word "
+
+
+definition update_SV57_Vaddr_PgOfs  :: \<open> SV57_Vaddr \<Rightarrow>(12)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_PgOfs v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(12)Word.word "
+
+
+definition get_SV57_Vaddr_VPNi  :: \<open> SV57_Vaddr \<Rightarrow>(27)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_VPNi v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 38 :: int)::ii) (( 12 :: int)::ii)  ::  27 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_VPNi  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(27)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_VPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 38 :: int)::ii) (( 12 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(27)Word.word "
+
+
+definition update_SV57_Vaddr_VPNi  :: \<open> SV57_Vaddr \<Rightarrow>(27)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_VPNi v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 38 :: int)::ii) (( 12 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(27)Word.word "
+
+
+\<comment> \<open>\<open>val undefined_SV57_Paddr : unit -> M SV57_Paddr\<close>\<close>
+
+definition undefined_SV57_Paddr  :: \<open> unit \<Rightarrow>((register_value),(SV57_Paddr),(exception))monad \<close>  where 
+     \<open> undefined_SV57_Paddr _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 56 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      56 Word.word) . 
+   return ((| SV57_Paddr_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_Paddr : mword ty56 -> SV57_Paddr\<close>\<close>
+
+definition Mk_SV57_Paddr  :: \<open>(56)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> Mk_SV57_Paddr v = ( (| SV57_Paddr_bits = v |) )\<close> 
+  for  v  :: "(56)Word.word "
+
+
+definition get_SV57_Paddr_bits  :: \<open> SV57_Paddr \<Rightarrow>(56)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_bits v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 0 :: int)::ii)  ::  56 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_bits  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(56)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 55 :: int)::ii) (( 0 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(56)Word.word "
+
+
+definition update_SV57_Paddr_bits  :: \<open> SV57_Paddr \<Rightarrow>(56)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_bits v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 0 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(56)Word.word "
+
+
+definition get_SV57_Paddr_PPNi  :: \<open> SV57_Paddr \<Rightarrow>(44)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_PPNi v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 12 :: int)::ii)  ::  44 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_PPNi  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(44)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_PPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 55 :: int)::ii) (( 12 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(44)Word.word "
+
+
+definition update_SV57_Paddr_PPNi  :: \<open> SV57_Paddr \<Rightarrow>(44)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_PPNi v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 12 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(44)Word.word "
+
+
+definition get_SV57_Paddr_PgOfs  :: \<open> SV57_Paddr \<Rightarrow>(12)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_PgOfs v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_PgOfs  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(12)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_PgOfs r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 11 :: int)::ii) (( 0 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(12)Word.word "
+
+
+definition update_SV57_Paddr_PgOfs  :: \<open> SV57_Paddr \<Rightarrow>(12)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_PgOfs v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(12)Word.word "
+
+
+\<comment> \<open>\<open>val undefined_SV57_PTE : unit -> M SV57_PTE\<close>\<close>
+
+definition undefined_SV57_PTE  :: \<open> unit \<Rightarrow>((register_value),(SV57_PTE),(exception))monad \<close>  where 
+     \<open> undefined_SV57_PTE _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      64 Word.word) . 
+   return ((| SV57_PTE_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_PTE : mword ty64 -> SV57_PTE\<close>\<close>
+
+definition Mk_SV57_PTE  :: \<open>(64)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> Mk_SV57_PTE v = ( (| SV57_PTE_bits = v |) )\<close> 
+  for  v  :: "(64)Word.word "
+
+
+definition get_SV57_PTE_bits  :: \<open> SV57_PTE \<Rightarrow>(64)Word.word \<close>  where 
+     \<open> get_SV57_PTE_bits v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 0 :: int)::ii)  ::  64 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_bits  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 63 :: int)::ii) (( 0 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(64)Word.word "
+
+
+definition update_SV57_PTE_bits  :: \<open> SV57_PTE \<Rightarrow>(64)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_bits v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 0 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(64)Word.word "
+
+
+definition get_SV57_PTE_BITS  :: \<open> SV57_PTE \<Rightarrow>(8)Word.word \<close>  where 
+     \<open> get_SV57_PTE_BITS v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 7 :: int)::ii) (( 0 :: int)::ii)  ::  8 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_BITS  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(8)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_BITS r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 7 :: int)::ii) (( 0 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(8)Word.word "
+
+
+definition update_SV57_PTE_BITS  :: \<open> SV57_PTE \<Rightarrow>(8)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_BITS v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 7 :: int)::ii) (( 0 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(8)Word.word "
+
+
+definition get_SV57_PTE_Ext  :: \<open> SV57_PTE \<Rightarrow>(10)Word.word \<close>  where 
+     \<open> get_SV57_PTE_Ext v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 54 :: int)::ii)  ::  10 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_Ext  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(10)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_Ext r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 63 :: int)::ii) (( 54 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(10)Word.word "
+
+
+definition update_SV57_PTE_Ext  :: \<open> SV57_PTE \<Rightarrow>(10)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_Ext v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 54 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(10)Word.word "
+
+
+definition get_SV57_PTE_PPNi  :: \<open> SV57_PTE \<Rightarrow>(44)Word.word \<close>  where 
+     \<open> get_SV57_PTE_PPNi v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii)  ::  44 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_PPNi  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(44)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_PPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 53 :: int)::ii) (( 10 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(44)Word.word "
+
+
+definition update_SV57_PTE_PPNi  :: \<open> SV57_PTE \<Rightarrow>(44)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_PPNi v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(44)Word.word "
+
+
+definition get_SV57_PTE_RSW  :: \<open> SV57_PTE \<Rightarrow>(2)Word.word \<close>  where 
+     \<open> get_SV57_PTE_RSW v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 9 :: int)::ii) (( 8 :: int)::ii)  ::  2 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_RSW  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(2)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_RSW r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 9 :: int)::ii) (( 8 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(2)Word.word "
+
+
+definition update_SV57_PTE_RSW  :: \<open> SV57_PTE \<Rightarrow>(2)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_RSW v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 9 :: int)::ii) (( 8 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(2)Word.word "
 
 \<comment> \<open>\<open>val make_TLB_Entry : forall 'asidlen 'palen 'ptelen 'valen. Size 'asidlen, Size 'palen, Size 'ptelen, Size 'valen => mword 'asidlen -> bool -> mword 'valen -> mword 'palen -> mword 'ptelen -> ii -> mword 'palen -> ii -> M (TLB_Entry 'asidlen 'valen 'palen 'ptelen)\<close>\<close>
 

--- a/prover_snapshots/isabelle/RV32/Riscv_types.thy
+++ b/prover_snapshots/isabelle/RV32/Riscv_types.thy
@@ -372,7 +372,7 @@ datatype ExtStatus =   Off | Initial | Clean | Dirty
 
 type_synonym satp_mode  =" 4 bits "
 
-datatype SATPMode =   Sbare | Sv32 | Sv39 | Sv48
+datatype SATPMode =   Sbare | Sv32 | Sv39 | Sv48 | Sv57
 
 
 
@@ -520,6 +520,21 @@ record SV48_Vaddr  =
 
 
 
+record SV57_PTE  = 
+ SV57_PTE_bits ::"  64 Word.word "  
+
+
+
+record SV57_Paddr  = 
+ SV57_Paddr_bits ::"  56 Word.word "  
+
+
+
+record SV57_Vaddr  = 
+ SV57_Vaddr_bits ::"  57 Word.word "  
+
+
+
 record Satp32  = 
  Satp32_bits ::"  32 Word.word "  
 
@@ -664,7 +679,11 @@ type_synonym vaddr39  =" 39 bits "
 
 type_synonym vaddr48  =" 48 bits "
 
+type_synonym vaddr57  =" 57 bits "
+
 type_synonym pte48  =" 64 bits "
+
+type_synonym pte57  =" 64 bits "
 
 datatype( 'paddr, 'pte) PTW_Result =
     PTW_Success " (('paddr * 'pte * 'paddr * ii * bool * ext_ptw))"

--- a/prover_snapshots/isabelle/RV64/Riscv.thy
+++ b/prover_snapshots/isabelle/RV64/Riscv.thy
@@ -2402,7 +2402,8 @@ definition SATPMode_of_num  :: \<open> int \<Rightarrow> SATPMode \<close>  wher
    if (((l__240 = (( 0 :: int)::ii)))) then Sbare
    else if (((l__240 = (( 1 :: int)::ii)))) then Sv32
    else if (((l__240 = (( 2 :: int)::ii)))) then Sv39
-   else Sv48))\<close> 
+   else if (((l__240 = (( 3 :: int)::ii)))) then Sv48
+   else Sv57))\<close> 
   for  arg1  :: " int "
 
 
@@ -2413,6 +2414,7 @@ fun num_of_SATPMode  :: \<open> SATPMode \<Rightarrow> int \<close>  where
 |\<open> num_of_SATPMode Sv32 = ( (( 1 :: int)::ii))\<close>
 |\<open> num_of_SATPMode Sv39 = ( (( 2 :: int)::ii))\<close>
 |\<open> num_of_SATPMode Sv48 = ( (( 3 :: int)::ii))\<close>
+|\<open> num_of_SATPMode Sv57 = ( (( 4 :: int)::ii))\<close>
 
 
 \<comment> \<open>\<open>val satp64Mode_of_bits : Architecture -> mword ty4 -> maybe SATPMode\<close>\<close>
@@ -2428,6 +2430,7 @@ definition satp64Mode_of_bits  :: \<open> Architecture \<Rightarrow>(4)Word.word
         | (RV64, b__0) =>
            if (((b__0 = ( 0x8 ::  4 Word.word)))) then Some Sv39
            else if (((b__0 = ( 0x9 ::  4 Word.word)))) then Some Sv48
+           else if (((b__0 = ( 0xA ::  4 Word.word)))) then Some Sv57
            else (case  (RV64, b__0) of   (_, _) => None )
         | (_, _) => None
         ))\<close> 
@@ -4584,6 +4587,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(64)Word.word \<Righta
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_bits : SV57_PTE -> mword ty64 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Paddr_bits : SV57_Paddr -> mword ty56 -> SV57_Paddr\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _update_Satp32_bits : Satp32 -> mword ty32 -> Satp32\<close>\<close>
 
 \<comment> \<open>\<open>val _update_Satp64_bits : Satp64 -> mword ty64 -> Satp64\<close>\<close>
@@ -4640,6 +4649,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(64)Word.word \<Righta
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_bits : SV48_Vaddr -> mword ty48\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_bits : SV57_PTE -> mword ty64\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Paddr_bits : SV57_Paddr -> mword ty56\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Vaddr_bits : SV57_Vaddr -> mword ty57\<close>\<close>
+
 \<comment> \<open>\<open>val _get_Satp32_bits : Satp32 -> mword ty32\<close>\<close>
 
 \<comment> \<open>\<open>val _get_Satp64_bits : Satp64 -> mword ty64\<close>\<close>
@@ -4695,6 +4710,12 @@ definition update_Misa_bits  :: \<open> Misa \<Rightarrow>(64)Word.word \<Righta
 \<comment> \<open>\<open>val _set_SV48_Paddr_bits : register_ref regstate register_value SV48_Paddr -> mword ty56 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_bits : register_ref regstate register_value SV48_Vaddr -> mword ty48 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_bits : register_ref regstate register_value SV57_PTE -> mword ty64 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_bits : register_ref regstate register_value SV57_Paddr -> mword ty56 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_bits : register_ref regstate register_value SV57_Vaddr -> mword ty57 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_Satp32_bits : register_ref regstate register_value Satp32 -> mword ty32 -> M unit\<close>\<close>
 
@@ -17323,6 +17344,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12 -> SV57_Paddr\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV32_Paddr_PgOfs : SV32_Paddr -> mword ty12\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV39_Paddr_PgOfs : SV39_Paddr -> mword ty12\<close>\<close>
@@ -17333,6 +17358,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_PgOfs : SV48_Vaddr -> mword ty12\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_Paddr_PgOfs : SV57_Paddr -> mword ty12\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Vaddr_PgOfs : SV57_Vaddr -> mword ty12\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV32_Paddr_PgOfs : register_ref regstate register_value SV32_Paddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV39_Paddr_PgOfs : register_ref regstate register_value SV39_Paddr -> mword ty12 -> M unit\<close>\<close>
@@ -17342,6 +17371,10 @@ definition update_SV32_Vaddr_PgOfs  :: \<open> SV32_Vaddr \<Rightarrow>(12)Word.
 \<comment> \<open>\<open>val _set_SV48_Paddr_PgOfs : register_ref regstate register_value SV48_Paddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_PgOfs : register_ref regstate register_value SV48_Vaddr -> mword ty12 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_PgOfs : register_ref regstate register_value SV57_Paddr -> mword ty12 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_PgOfs : register_ref regstate register_value SV57_Vaddr -> mword ty12 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV32_Vaddr_VPNi : SV32_Vaddr -> mword ty20\<close>\<close>
 
@@ -17378,13 +17411,19 @@ definition update_SV32_Vaddr_VPNi  :: \<open> SV32_Vaddr \<Rightarrow>(20)Word.w
 
 \<comment> \<open>\<open>val _update_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27 -> SV48_Vaddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27 -> SV57_Vaddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_Vaddr_VPNi : SV39_Vaddr -> mword ty27\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_Vaddr_VPNi : SV48_Vaddr -> mword ty27\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_Vaddr_VPNi : SV57_Vaddr -> mword ty27\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_Vaddr_VPNi : register_ref regstate register_value SV39_Vaddr -> mword ty27 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Vaddr_VPNi : register_ref regstate register_value SV48_Vaddr -> mword ty27 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Vaddr_VPNi : register_ref regstate register_value SV57_Vaddr -> mword ty27 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val undefined_SV32_Paddr : unit -> M SV32_Paddr\<close>\<close>
 
@@ -17468,6 +17507,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 
 \<comment> \<open>\<open>val _update_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44 -> SV48_Paddr\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_PPNi : SV57_PTE -> mword ty44 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _update_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44 -> SV57_Paddr\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV32_PTE_PPNi : SV32_PTE -> mword ty22\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV39_PTE_PPNi : SV39_PTE -> mword ty44\<close>\<close>
@@ -17478,6 +17521,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 
 \<comment> \<open>\<open>val _get_SV48_Paddr_PPNi : SV48_Paddr -> mword ty44\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_PPNi : SV57_PTE -> mword ty44\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_Paddr_PPNi : SV57_Paddr -> mword ty44\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV32_PTE_PPNi : register_ref regstate register_value SV32_PTE -> mword ty22 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV39_PTE_PPNi : register_ref regstate register_value SV39_PTE -> mword ty44 -> M unit\<close>\<close>
@@ -17487,6 +17534,10 @@ definition update_SV32_Paddr_PPNi  :: \<open> SV32_Paddr \<Rightarrow>(22)Word.w
 \<comment> \<open>\<open>val _set_SV48_PTE_PPNi : register_ref regstate register_value SV48_PTE -> mword ty44 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_Paddr_PPNi : register_ref regstate register_value SV48_Paddr -> mword ty44 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_PPNi : register_ref regstate register_value SV57_PTE -> mword ty44 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_Paddr_PPNi : register_ref regstate register_value SV57_Paddr -> mword ty44 -> M unit\<close>\<close>
 
 definition get_SV32_Paddr_PgOfs  :: \<open> SV32_Paddr \<Rightarrow>(12)Word.word \<close>  where 
      \<open> get_SV32_Paddr_PgOfs v = ( (subrange_vec_dec(SV32_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
@@ -17587,13 +17638,19 @@ definition update_SV32_PTE_BITS  :: \<open> SV32_PTE \<Rightarrow>(8)Word.word \
 
 \<comment> \<open>\<open>val _update_SV48_PTE_BITS : SV48_PTE -> mword ty8 -> SV48_PTE\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_BITS : SV57_PTE -> mword ty8 -> SV57_PTE\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_PTE_BITS : SV39_PTE -> mword ty8\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_PTE_BITS : SV48_PTE -> mword ty8\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_BITS : SV57_PTE -> mword ty8\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_PTE_BITS : register_ref regstate register_value SV39_PTE -> mword ty8 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_PTE_BITS : register_ref regstate register_value SV48_PTE -> mword ty8 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_BITS : register_ref regstate register_value SV57_PTE -> mword ty8 -> M unit\<close>\<close>
 
 definition get_SV32_PTE_PPNi  :: \<open> SV32_PTE \<Rightarrow>(22)Word.word \<close>  where 
      \<open> get_SV32_PTE_PPNi v = ( (subrange_vec_dec(SV32_PTE_bits   v) (( 31 :: int)::ii) (( 10 :: int)::ii)  ::  22 Word.word))\<close> 
@@ -17653,13 +17710,19 @@ definition update_SV32_PTE_RSW  :: \<open> SV32_PTE \<Rightarrow>(2)Word.word \<
 
 \<comment> \<open>\<open>val _update_SV48_PTE_RSW : SV48_PTE -> mword ty2 -> SV48_PTE\<close>\<close>
 
+\<comment> \<open>\<open>val _update_SV57_PTE_RSW : SV57_PTE -> mword ty2 -> SV57_PTE\<close>\<close>
+
 \<comment> \<open>\<open>val _get_SV39_PTE_RSW : SV39_PTE -> mword ty2\<close>\<close>
 
 \<comment> \<open>\<open>val _get_SV48_PTE_RSW : SV48_PTE -> mword ty2\<close>\<close>
 
+\<comment> \<open>\<open>val _get_SV57_PTE_RSW : SV57_PTE -> mword ty2\<close>\<close>
+
 \<comment> \<open>\<open>val _set_SV39_PTE_RSW : register_ref regstate register_value SV39_PTE -> mword ty2 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val _set_SV48_PTE_RSW : register_ref regstate register_value SV48_PTE -> mword ty2 -> M unit\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_RSW : register_ref regstate register_value SV57_PTE -> mword ty2 -> M unit\<close>\<close>
 
 \<comment> \<open>\<open>val curAsid64 : mword ty64 -> mword ty16\<close>\<close>
 
@@ -18312,6 +18375,12 @@ definition update_SV48_PTE_Ext  :: \<open> SV48_PTE \<Rightarrow>(10)Word.word \
   and  x  :: "(10)Word.word "
 
 
+\<comment> \<open>\<open>val _update_SV57_PTE_Ext : SV57_PTE -> mword ty10 -> SV57_PTE\<close>\<close>
+
+\<comment> \<open>\<open>val _get_SV57_PTE_Ext : SV57_PTE -> mword ty10\<close>\<close>
+
+\<comment> \<open>\<open>val _set_SV57_PTE_Ext : register_ref regstate register_value SV57_PTE -> mword ty10 -> M unit\<close>\<close>
+
 definition get_SV48_PTE_PPNi  :: \<open> SV48_PTE \<Rightarrow>(44)Word.word \<close>  where 
      \<open> get_SV48_PTE_PPNi v = ( (subrange_vec_dec(SV48_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii)  ::  44 Word.word))\<close> 
   for  v  :: " SV48_PTE "
@@ -18357,6 +18426,340 @@ definition update_SV48_PTE_RSW  :: \<open> SV48_PTE \<Rightarrow>(2)Word.word \<
    ( v (|
      SV48_PTE_bits := ((update_subrange_vec_dec(SV48_PTE_bits   v) (( 9 :: int)::ii) (( 8 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
   for  v  :: " SV48_PTE " 
+  and  x  :: "(2)Word.word "
+
+
+definition SV57_LEVEL_BITS  :: \<open> int \<close>  where 
+     \<open> SV57_LEVEL_BITS = ( (( 9 :: int)::ii))\<close>
+
+
+definition SV57_LEVELS  :: \<open> int \<close>  where 
+     \<open> SV57_LEVELS = ( (( 5 :: int)::ii))\<close>
+
+
+definition PTE57_LOG_SIZE  :: \<open> int \<close>  where 
+     \<open> PTE57_LOG_SIZE = ( (( 3 :: int)::ii))\<close>
+
+
+definition PTE57_SIZE  :: \<open> int \<close>  where 
+     \<open> PTE57_SIZE = ( (( 8 :: int)::ii))\<close>
+
+
+\<comment> \<open>\<open>val undefined_SV57_Vaddr : unit -> M SV57_Vaddr\<close>\<close>
+
+definition undefined_SV57_Vaddr  :: \<open> unit \<Rightarrow>((register_value),(SV57_Vaddr),(exception))monad \<close>  where 
+     \<open> undefined_SV57_Vaddr _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 57 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      57 Word.word) . 
+   return ((| SV57_Vaddr_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_Vaddr : mword ty57 -> SV57_Vaddr\<close>\<close>
+
+definition Mk_SV57_Vaddr  :: \<open>(57)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> Mk_SV57_Vaddr v = ( (| SV57_Vaddr_bits = v |) )\<close> 
+  for  v  :: "(57)Word.word "
+
+
+definition get_SV57_Vaddr_bits  :: \<open> SV57_Vaddr \<Rightarrow>(57)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_bits v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 56 :: int)::ii) (( 0 :: int)::ii)  ::  57 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_bits  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(57)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 56 :: int)::ii) (( 0 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(57)Word.word "
+
+
+definition update_SV57_Vaddr_bits  :: \<open> SV57_Vaddr \<Rightarrow>(57)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_bits v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 56 :: int)::ii) (( 0 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(57)Word.word "
+
+
+definition get_SV57_Vaddr_PgOfs  :: \<open> SV57_Vaddr \<Rightarrow>(12)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_PgOfs v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_PgOfs  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(12)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_PgOfs r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 11 :: int)::ii) (( 0 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(12)Word.word "
+
+
+definition update_SV57_Vaddr_PgOfs  :: \<open> SV57_Vaddr \<Rightarrow>(12)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_PgOfs v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(12)Word.word "
+
+
+definition get_SV57_Vaddr_VPNi  :: \<open> SV57_Vaddr \<Rightarrow>(27)Word.word \<close>  where 
+     \<open> get_SV57_Vaddr_VPNi v = ( (subrange_vec_dec(SV57_Vaddr_bits   v) (( 38 :: int)::ii) (( 12 :: int)::ii)  ::  27 Word.word))\<close> 
+  for  v  :: " SV57_Vaddr "
+
+
+definition set_SV57_Vaddr_VPNi  :: \<open>((regstate),(register_value),(SV57_Vaddr))register_ref \<Rightarrow>(27)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Vaddr_VPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Vaddr_bits :=
+         ((update_subrange_vec_dec(SV57_Vaddr_bits   r) (( 38 :: int)::ii) (( 12 :: int)::ii) v  ::  57 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Vaddr))register_ref " 
+  and  v  :: "(27)Word.word "
+
+
+definition update_SV57_Vaddr_VPNi  :: \<open> SV57_Vaddr \<Rightarrow>(27)Word.word \<Rightarrow> SV57_Vaddr \<close>  where 
+     \<open> update_SV57_Vaddr_VPNi v x = (
+   ( v (|
+     SV57_Vaddr_bits := ((update_subrange_vec_dec(SV57_Vaddr_bits   v) (( 38 :: int)::ii) (( 12 :: int)::ii) x  ::  57 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Vaddr " 
+  and  x  :: "(27)Word.word "
+
+
+\<comment> \<open>\<open>val undefined_SV57_Paddr : unit -> M SV57_Paddr\<close>\<close>
+
+definition undefined_SV57_Paddr  :: \<open> unit \<Rightarrow>((register_value),(SV57_Paddr),(exception))monad \<close>  where 
+     \<open> undefined_SV57_Paddr _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 56 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      56 Word.word) . 
+   return ((| SV57_Paddr_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_Paddr : mword ty56 -> SV57_Paddr\<close>\<close>
+
+definition Mk_SV57_Paddr  :: \<open>(56)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> Mk_SV57_Paddr v = ( (| SV57_Paddr_bits = v |) )\<close> 
+  for  v  :: "(56)Word.word "
+
+
+definition get_SV57_Paddr_bits  :: \<open> SV57_Paddr \<Rightarrow>(56)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_bits v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 0 :: int)::ii)  ::  56 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_bits  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(56)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 55 :: int)::ii) (( 0 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(56)Word.word "
+
+
+definition update_SV57_Paddr_bits  :: \<open> SV57_Paddr \<Rightarrow>(56)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_bits v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 0 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(56)Word.word "
+
+
+definition get_SV57_Paddr_PPNi  :: \<open> SV57_Paddr \<Rightarrow>(44)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_PPNi v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 12 :: int)::ii)  ::  44 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_PPNi  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(44)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_PPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 55 :: int)::ii) (( 12 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(44)Word.word "
+
+
+definition update_SV57_Paddr_PPNi  :: \<open> SV57_Paddr \<Rightarrow>(44)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_PPNi v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 55 :: int)::ii) (( 12 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(44)Word.word "
+
+
+definition get_SV57_Paddr_PgOfs  :: \<open> SV57_Paddr \<Rightarrow>(12)Word.word \<close>  where 
+     \<open> get_SV57_Paddr_PgOfs v = ( (subrange_vec_dec(SV57_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii)  ::  12 Word.word))\<close> 
+  for  v  :: " SV57_Paddr "
+
+
+definition set_SV57_Paddr_PgOfs  :: \<open>((regstate),(register_value),(SV57_Paddr))register_ref \<Rightarrow>(12)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_Paddr_PgOfs r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_Paddr_bits :=
+         ((update_subrange_vec_dec(SV57_Paddr_bits   r) (( 11 :: int)::ii) (( 0 :: int)::ii) v  ::  56 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_Paddr))register_ref " 
+  and  v  :: "(12)Word.word "
+
+
+definition update_SV57_Paddr_PgOfs  :: \<open> SV57_Paddr \<Rightarrow>(12)Word.word \<Rightarrow> SV57_Paddr \<close>  where 
+     \<open> update_SV57_Paddr_PgOfs v x = (
+   ( v (|
+     SV57_Paddr_bits := ((update_subrange_vec_dec(SV57_Paddr_bits   v) (( 11 :: int)::ii) (( 0 :: int)::ii) x  ::  56 Word.word)) |)))\<close> 
+  for  v  :: " SV57_Paddr " 
+  and  x  :: "(12)Word.word "
+
+
+\<comment> \<open>\<open>val undefined_SV57_PTE : unit -> M SV57_PTE\<close>\<close>
+
+definition undefined_SV57_PTE  :: \<open> unit \<Rightarrow>((register_value),(SV57_PTE),(exception))monad \<close>  where 
+     \<open> undefined_SV57_PTE _ = (
+   ((return (failwith (''undefined value of unsupported type''))) :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::
+      64 Word.word) . 
+   return ((| SV57_PTE_bits = w__0 |)))))\<close>
+
+
+\<comment> \<open>\<open>val Mk_SV57_PTE : mword ty64 -> SV57_PTE\<close>\<close>
+
+definition Mk_SV57_PTE  :: \<open>(64)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> Mk_SV57_PTE v = ( (| SV57_PTE_bits = v |) )\<close> 
+  for  v  :: "(64)Word.word "
+
+
+definition get_SV57_PTE_bits  :: \<open> SV57_PTE \<Rightarrow>(64)Word.word \<close>  where 
+     \<open> get_SV57_PTE_bits v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 0 :: int)::ii)  ::  64 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_bits  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_bits r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 63 :: int)::ii) (( 0 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(64)Word.word "
+
+
+definition update_SV57_PTE_bits  :: \<open> SV57_PTE \<Rightarrow>(64)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_bits v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 0 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(64)Word.word "
+
+
+definition get_SV57_PTE_BITS  :: \<open> SV57_PTE \<Rightarrow>(8)Word.word \<close>  where 
+     \<open> get_SV57_PTE_BITS v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 7 :: int)::ii) (( 0 :: int)::ii)  ::  8 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_BITS  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(8)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_BITS r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 7 :: int)::ii) (( 0 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(8)Word.word "
+
+
+definition update_SV57_PTE_BITS  :: \<open> SV57_PTE \<Rightarrow>(8)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_BITS v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 7 :: int)::ii) (( 0 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(8)Word.word "
+
+
+definition get_SV57_PTE_Ext  :: \<open> SV57_PTE \<Rightarrow>(10)Word.word \<close>  where 
+     \<open> get_SV57_PTE_Ext v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 54 :: int)::ii)  ::  10 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_Ext  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(10)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_Ext r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 63 :: int)::ii) (( 54 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(10)Word.word "
+
+
+definition update_SV57_PTE_Ext  :: \<open> SV57_PTE \<Rightarrow>(10)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_Ext v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 63 :: int)::ii) (( 54 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(10)Word.word "
+
+
+definition get_SV57_PTE_PPNi  :: \<open> SV57_PTE \<Rightarrow>(44)Word.word \<close>  where 
+     \<open> get_SV57_PTE_PPNi v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii)  ::  44 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_PPNi  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(44)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_PPNi r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 53 :: int)::ii) (( 10 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(44)Word.word "
+
+
+definition update_SV57_PTE_PPNi  :: \<open> SV57_PTE \<Rightarrow>(44)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_PPNi v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 53 :: int)::ii) (( 10 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
+  and  x  :: "(44)Word.word "
+
+
+definition get_SV57_PTE_RSW  :: \<open> SV57_PTE \<Rightarrow>(2)Word.word \<close>  where 
+     \<open> get_SV57_PTE_RSW v = ( (subrange_vec_dec(SV57_PTE_bits   v) (( 9 :: int)::ii) (( 8 :: int)::ii)  ::  2 Word.word))\<close> 
+  for  v  :: " SV57_PTE "
+
+
+definition set_SV57_PTE_RSW  :: \<open>((regstate),(register_value),(SV57_PTE))register_ref \<Rightarrow>(2)Word.word \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> set_SV57_PTE_RSW r_ref v = (
+   read_reg r_ref \<bind> ((\<lambda> r . 
+   (let r =
+     (( r (|
+       SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   r) (( 9 :: int)::ii) (( 8 :: int)::ii) v  ::  64 Word.word)) |))) in
+   write_reg r_ref r))))\<close> 
+  for  r_ref  :: "((regstate),(register_value),(SV57_PTE))register_ref " 
+  and  v  :: "(2)Word.word "
+
+
+definition update_SV57_PTE_RSW  :: \<open> SV57_PTE \<Rightarrow>(2)Word.word \<Rightarrow> SV57_PTE \<close>  where 
+     \<open> update_SV57_PTE_RSW v x = (
+   ( v (|
+     SV57_PTE_bits := ((update_subrange_vec_dec(SV57_PTE_bits   v) (( 9 :: int)::ii) (( 8 :: int)::ii) x  ::  64 Word.word)) |)))\<close> 
+  for  v  :: " SV57_PTE " 
   and  x  :: "(2)Word.word "
 
 
@@ -18856,6 +19259,198 @@ definition translate48  :: \<open>(16)Word.word \<Rightarrow>(56)Word.word \<Rig
 definition init_vmem_sv48  :: \<open> unit \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
      \<open> init_vmem_sv48 _ = ( write_reg tlb48_ref None )\<close>
 
+\<comment> \<open>\<open>val walk57 : mword ty57 -> AccessType unit -> Privilege -> bool -> bool -> mword ty56 -> ii -> bool -> unit -> M (PTW_Result (mword ty56) SV57_PTE)\<close>\<close>
+
+function (sequential,domintros)  walk57  :: \<open>(57)Word.word \<Rightarrow>(unit)AccessType \<Rightarrow> Privilege \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow>(56)Word.word \<Rightarrow> int \<Rightarrow> bool \<Rightarrow> unit \<Rightarrow>((register_value),((((56)Word.word),(SV57_PTE))PTW_Result),(exception))monad \<close>  where 
+     \<open> walk57 vaddr ac priv mxr do_sum ptb level global1 ext_ptw = (
+   (let va = (Mk_SV57_Vaddr vaddr) in
+   (let (pt_ofs :: paddr64) =
+     ((shiftl
+        ((EXTZ (( 56 :: int)::ii)
+            ((subrange_vec_dec
+                ((shiftr ((get_SV57_Vaddr_VPNi va  ::  27 Word.word))
+                    ((level * SV57_LEVEL_BITS))
+                   ::  27 Word.word)) ((SV57_LEVEL_BITS - (( 1 :: int)::ii))) (( 0 :: int)::ii)
+               ::  9 Word.word))
+           ::  56 Word.word)) PTE57_LOG_SIZE
+       ::  56 Word.word)) in
+   (let pte_addr = ((add_vec ptb pt_ofs  ::  56 Word.word)) in
+   (mem_read_priv (Read Data) Supervisor ((EXTZ (( 64 :: int)::ii) pte_addr  ::  64 Word.word)) (( 8 :: int)::ii) False False
+      False
+     :: ( ( 64 Word.word)MemoryOpResult) M) \<bind> ((\<lambda> (w__0 :: ( 64 Word.word) MemoryOpResult) . 
+   (case  w__0 of
+     MemException (_) => return (PTW_Failure (PTW_Access () , ext_ptw))
+   | MemValue (v) =>
+      (let pte = (Mk_SV57_PTE v) in
+      (let pbits = ((get_SV57_PTE_BITS pte  ::  8 Word.word)) in
+      (let ext_pte = ((get_SV57_PTE_Ext pte  ::  10 Word.word)) in
+      (let pattr = (Mk_PTE_Bits pbits) in
+      (let is_global =
+        (global1 \<or> (((((get_PTE_Bits_G pattr  ::  1 Word.word)) = ( 0b1 ::  1 Word.word))))) in
+      if ((isInvalidPTE pbits ext_pte)) then return (PTW_Failure (PTW_Invalid_PTE () , ext_ptw))
+      else if ((isPTEPtr pbits ext_pte)) then
+        if ((level > (( 0 :: int)::ii))) then
+          (walk57 vaddr ac priv mxr do_sum
+             ((shiftl ((EXTZ (( 56 :: int)::ii) ((get_SV57_PTE_PPNi pte  ::  44 Word.word))  ::  56 Word.word))
+                 PAGESIZE_BITS
+                ::  56 Word.word)) ((level - (( 1 :: int)::ii))) is_global ext_ptw
+            :: ( (( 56 Word.word), SV57_PTE)PTW_Result) M)
+        else return (PTW_Failure (PTW_Invalid_PTE () , ext_ptw))
+      else
+        checkPTEPermission ac priv mxr do_sum pattr ext_pte ext_ptw \<bind> ((\<lambda> (w__3 :: PTE_Check) . 
+        return ((case  w__3 of
+          PTE_Check_Failure ((ext_ptw, ext_ptw_fail)) =>
+           PTW_Failure (ext_get_ptw_error ext_ptw_fail, ext_ptw)
+        | PTE_Check_Success (ext_ptw) =>
+           if ((level > (( 0 :: int)::ii))) then
+             (let mask1 =
+               ((sub_vec_int
+                  ((shiftl
+                      ((xor_vec ((get_SV57_PTE_PPNi pte  ::  44 Word.word))
+                          ((xor_vec ((get_SV57_PTE_PPNi pte  ::  44 Word.word))
+                              ((EXTZ (( 44 :: int)::ii) ( 0b1 ::  1 Word.word)  ::  44 Word.word))
+                             ::  44 Word.word))
+                         ::  44 Word.word)) ((level * SV57_LEVEL_BITS))
+                     ::  44 Word.word)) (( 1 :: int)::ii)
+                 ::  44 Word.word)) in
+             if (((((and_vec ((get_SV57_PTE_PPNi pte  ::  44 Word.word)) mask1  ::  44 Word.word)) \<noteq> ((EXTZ (( 44 :: int)::ii) ( 0b0 ::  1 Word.word)  ::  44 Word.word))))) then
+               PTW_Failure (PTW_Misaligned () , ext_ptw)
+             else
+               (let ppn =
+                 ((or_vec ((get_SV57_PTE_PPNi pte  ::  44 Word.word))
+                    ((and_vec
+                        ((EXTZ (( 44 :: int)::ii) ((get_SV57_Vaddr_VPNi va  ::  27 Word.word))  ::  44 Word.word))
+                        mask1
+                       ::  44 Word.word))
+                   ::  44 Word.word)) in
+               PTW_Success ((concat_vec ppn ((get_SV57_Vaddr_PgOfs va  ::  12 Word.word))  ::  56 Word.word),
+                            pte,
+                            pte_addr,
+                            level,
+                            is_global,
+                            ext_ptw)))
+           else
+             PTW_Success ((concat_vec ((get_SV57_PTE_PPNi pte  ::  44 Word.word))
+                             ((get_SV57_Vaddr_PgOfs va  ::  12 Word.word))
+                            ::  56 Word.word),
+                          pte,
+                          pte_addr,
+                          level,
+                          is_global,
+                          ext_ptw)
+        )))))))))
+   )))))))\<close> 
+  for  vaddr  :: "(57)Word.word " 
+  and  ac  :: "(unit)AccessType " 
+  and  priv  :: " Privilege " 
+  and  mxr  :: " bool " 
+  and  do_sum  :: " bool " 
+  and  ptb  :: "(56)Word.word " 
+  and  level  :: " int " 
+  and  global1  :: " bool " 
+  and  ext_ptw  :: " unit " 
+by pat_completeness (auto intro!: let_cong bind_cong MemoryOpResult.case_cong)
+
+
+\<comment> \<open>\<open>val lookup_TLB57 : mword ty16 -> mword ty57 -> M (maybe ((ii * TLB_Entry ty16 ty57 ty56 ty64)))\<close>\<close>
+
+definition lookup_TLB57  :: \<open>(16)Word.word \<Rightarrow>(57)Word.word \<Rightarrow>((register_value),((int*((16),(57),(56),(64))TLB_Entry)option),(exception))monad \<close>  where 
+     \<open> lookup_TLB57 asid vaddr = (
+   read_reg tlb57_ref \<bind> ((\<lambda> (w__0 ::  ( (16, 57, 56, 64)TLB_Entry)option) . 
+   return ((case  w__0 of
+     None => None
+   | Some (e) => if ((match_TLB_Entry e asid vaddr)) then Some ((( 0 :: int)::ii), e) else None
+   )))))\<close> 
+  for  asid  :: "(16)Word.word " 
+  and  vaddr  :: "(57)Word.word "
+
+
+\<comment> \<open>\<open>val add_to_TLB57 : mword ty16 -> mword ty57 -> mword ty56 -> SV57_PTE -> mword ty56 -> ii -> bool -> M unit\<close>\<close>
+
+definition add_to_TLB57  :: \<open>(16)Word.word \<Rightarrow>(57)Word.word \<Rightarrow>(56)Word.word \<Rightarrow> SV57_PTE \<Rightarrow>(56)Word.word \<Rightarrow> int \<Rightarrow> bool \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> add_to_TLB57 asid vAddr pAddr pte pteAddr level global1 = (
+   make_TLB_Entry asid global1 vAddr pAddr ((get_SV57_PTE_bits pte  ::  64 Word.word)) level pteAddr
+     SV57_LEVEL_BITS \<bind> ((\<lambda> (ent :: TLB57_Entry) . 
+   write_reg tlb57_ref (Some ent))))\<close> 
+  for  asid  :: "(16)Word.word " 
+  and  vAddr  :: "(57)Word.word " 
+  and  pAddr  :: "(56)Word.word " 
+  and  pte  :: " SV57_PTE " 
+  and  pteAddr  :: "(56)Word.word " 
+  and  level  :: " int " 
+  and  global1  :: " bool "
+
+
+\<comment> \<open>\<open>val write_TLB57 : ii -> TLB_Entry ty16 ty57 ty56 ty64 -> M unit\<close>\<close>
+
+definition write_TLB57  :: \<open> int \<Rightarrow>((16),(57),(56),(64))TLB_Entry \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> write_TLB57 (idx :: ii) (ent :: TLB57_Entry) = ( write_reg tlb57_ref (Some ent))\<close> 
+  for  idx  :: " int " 
+  and  ent  :: "((16),(57),(56),(64))TLB_Entry "
+
+
+\<comment> \<open>\<open>val flush_TLB57 : maybe (mword ty16) -> maybe (mword ty57) -> M unit\<close>\<close>
+
+definition flush_TLB57  :: \<open>((16)Word.word)option \<Rightarrow>((57)Word.word)option \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> flush_TLB57 asid addr = (
+   read_reg tlb57_ref \<bind> ((\<lambda> (w__0 ::  ( (16, 57, 56, 64)TLB_Entry)option) . 
+   (case  w__0 of
+     None => return () 
+   | Some (e) => if ((flush_TLB_Entry e asid addr)) then write_reg tlb57_ref None else return () 
+   ))))\<close> 
+  for  asid  :: "((16)Word.word)option " 
+  and  addr  :: "((57)Word.word)option "
+
+
+\<comment> \<open>\<open>val translate57 : mword ty16 -> mword ty56 -> mword ty57 -> AccessType unit -> Privilege -> bool -> bool -> ii -> unit -> M (TR_Result (mword ty56) PTW_Error)\<close>\<close>
+
+definition translate57  :: \<open>(16)Word.word \<Rightarrow>(56)Word.word \<Rightarrow>(57)Word.word \<Rightarrow>(unit)AccessType \<Rightarrow> Privilege \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> int \<Rightarrow> unit \<Rightarrow>((register_value),((((56)Word.word),(PTW_Error))TR_Result),(exception))monad \<close>  where 
+     \<open> translate57 asid ptb vAddr ac priv mxr do_sum level ext_ptw = (
+   (walk57 vAddr ac priv mxr do_sum ptb level False ext_ptw  :: ( (( 56 Word.word), SV57_PTE)PTW_Result) M) \<bind> ((\<lambda> (w__0 :: (( 56 Word.word), SV57_PTE)
+     PTW_Result) . 
+   (case  w__0 of
+     PTW_Failure ((f, ext_ptw)) => return (TR_Failure (f, ext_ptw))
+   | PTW_Success ((pAddr, pte, pteAddr, level, global1, ext_ptw)) =>
+      (case  ((update_PTE_Bits ((Mk_PTE_Bits ((get_SV57_PTE_BITS pte  ::  8 Word.word)))) ac
+                ((get_SV57_PTE_Ext pte  ::  10 Word.word))
+               ::  ((PTE_Bits *  10 Word.word))option)) of
+        None =>
+         add_to_TLB57 asid vAddr pAddr pte pteAddr level global1 \<then>
+         return (TR_Address (pAddr, ext_ptw))
+      | Some ((pbits, ext)) =>
+         if ((\<not> ((plat_enable_dirty_update () )))) then
+           return (TR_Failure (PTW_PTE_Update () , ext_ptw))
+         else
+           (let (w_pte :: SV57_PTE) =
+             (update_SV57_PTE_BITS pte ((get_PTE_Bits_bits pbits  ::  8 Word.word))) in
+           (let (w_pte :: SV57_PTE) = (update_SV57_PTE_Ext w_pte ext) in
+           mem_write_value_priv ((EXTZ (( 64 :: int)::ii) pteAddr  ::  64 Word.word)) (( 8 :: int)::ii)
+             ((get_SV57_PTE_bits w_pte  ::  64 Word.word)) Supervisor False False False \<bind> ((\<lambda> (w__1 :: bool
+             MemoryOpResult) . 
+           (case  w__1 of
+             MemValue (_) =>
+              add_to_TLB57 asid vAddr pAddr w_pte pteAddr level global1 \<then>
+              return (TR_Address (pAddr, ext_ptw))
+           | MemException (e) => return (TR_Failure (PTW_Access () , ext_ptw))
+           )))))
+      )
+   ))))\<close> 
+  for  asid  :: "(16)Word.word " 
+  and  ptb  :: "(56)Word.word " 
+  and  vAddr  :: "(57)Word.word " 
+  and  ac  :: "(unit)AccessType " 
+  and  priv  :: " Privilege " 
+  and  mxr  :: " bool " 
+  and  do_sum  :: " bool " 
+  and  level  :: " int " 
+  and  ext_ptw  :: " unit "
+
+
+\<comment> \<open>\<open>val init_vmem_sv57 : unit -> M unit\<close>\<close>
+
+definition init_vmem_sv57  :: \<open> unit \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
+     \<open> init_vmem_sv57 _ = ( write_reg tlb57_ref None )\<close>
+
 
 \<comment> \<open>\<open>val legalize_satp : Architecture -> mword ty64 -> mword ty64 -> mword ty64\<close>\<close>
 
@@ -18886,6 +19481,14 @@ definition isValidSv48Addr  :: \<open>(64)Word.word \<Rightarrow> bool \<close> 
       else (zeros_implicit (((((( 63 :: int)::ii) - (( 48 :: int)::ii))) + (( 1 :: int)::ii)))  ::  16 Word.word))))\<close> 
   for  vAddr  :: "(64)Word.word "
 
+\<comment> \<open>\<open>val isValidSv57Addr : mword ty64 -> bool\<close>\<close>
+
+definition isValidSv57Addr  :: \<open>(64)Word.word \<Rightarrow> bool \<close>  where 
+     \<open> isValidSv57Addr vAddr = (
+   (((subrange_vec_dec vAddr (( 63 :: int)::ii) (( 57 :: int)::ii)  ::  16 Word.word)) = (if (((((access_vec_dec vAddr (( 56 :: int)::ii))) = B1))) then
+        (ones (((((( 63 :: int)::ii) - (( 57 :: int)::ii))) + (( 1 :: int)::ii)))  ::  16 Word.word)
+      else (zeros_implicit (((((( 63 :: int)::ii) - (( 57 :: int)::ii))) + (( 1 :: int)::ii)))  ::  16 Word.word))))\<close> 
+  for  vAddr  :: "(64)Word.word "
 
 \<comment> \<open>\<open>val translationMode : Privilege -> M SATPMode\<close>\<close>
 
@@ -18949,6 +19552,16 @@ definition translateAddr_priv  :: \<open>(64)Word.word \<Rightarrow>(unit)Access
         | TR_Failure ((f, ext_ptw)) => TR_Failure (translationException ac f, ext_ptw)
         ))))
       else return (TR_Failure (translationException ac (PTW_Invalid_Addr () ), ext_ptw))
+   | Sv57 =>
+      if ((isValidSv57Addr vAddr)) then
+        (translate57 asid ptb ((subrange_vec_dec vAddr (( 56 :: int)::ii) (( 0 :: int)::ii)  ::  57 Word.word)) ac effPriv mxr
+           do_sum ((SV57_LEVELS - (( 1 :: int)::ii))) ext_ptw
+          :: ( (( 56 Word.word), PTW_Error)TR_Result) M) \<bind> ((\<lambda> (w__6 :: (( 56 Word.word), PTW_Error) TR_Result) . 
+        return ((case  w__6 of
+          TR_Address ((pa, ext_ptw)) => TR_Address ((EXTZ (( 64 :: int)::ii) pa  ::  64 Word.word), ext_ptw)
+        | TR_Failure ((f, ext_ptw)) => TR_Failure (translationException ac f, ext_ptw)
+        ))))
+      else return (TR_Failure (translationException ac (PTW_Invalid_Addr () ), ext_ptw))
    | _ =>
       (internal_error (''unsupported address translation scheme'')
         :: ( (( 64 Word.word), ExceptionType)TR_Result) M)
@@ -18974,19 +19587,20 @@ definition translateAddr  :: \<open>(64)Word.word \<Rightarrow>(unit)AccessType 
 
 definition flush_TLB  :: \<open>((64)Word.word)option \<Rightarrow>((64)Word.word)option \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
      \<open> flush_TLB asid_xlen addr_xlen = (
-   (let ((addr39 ::  vaddr39 option), (addr48 ::  vaddr48 option)) =
+   (let ((addr39 ::  vaddr39 option), (addr48 ::  vaddr48 option), (addr57 ::  vaddr57 option)) =
      ((case  addr_xlen of
        None => (None, None)
      | Some (a) =>
         (Some ((subrange_vec_dec a (( 38 :: int)::ii) (( 0 :: int)::ii)  ::  39 Word.word)),
-         Some ((subrange_vec_dec a (( 47 :: int)::ii) (( 0 :: int)::ii)  ::  48 Word.word)))
+         Some ((subrange_vec_dec a (( 47 :: int)::ii) (( 0 :: int)::ii)  ::  48 Word.word)),
+         Some ((subrange_vec_dec a (( 56 :: int)::ii) (( 0 :: int)::ii)  ::  57 Word.word)))
      )) in
    (let (asid ::  asid64 option) =
      ((case  asid_xlen of
        None => None
      | Some (a) => Some ((subrange_vec_dec a (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))
      )) in
-   flush_TLB39 asid addr39 \<then> flush_TLB48 asid addr48)))\<close> 
+   flush_TLB39 asid addr39 \<then> flush_TLB48 asid addr48 \<then> flush_TLB57 asid addr57)))\<close> 
   for  asid_xlen  :: "((64)Word.word)option " 
   and  addr_xlen  :: "((64)Word.word)option "
 
@@ -18994,7 +19608,7 @@ definition flush_TLB  :: \<open>((64)Word.word)option \<Rightarrow>((64)Word.wor
 \<comment> \<open>\<open>val init_vmem : unit -> M unit\<close>\<close>
 
 definition init_vmem  :: \<open> unit \<Rightarrow>((register_value),(unit),(exception))monad \<close>  where 
-     \<open> init_vmem _ = ( init_vmem_sv39 ()  \<then> init_vmem_sv48 ()  )\<close>
+     \<open> init_vmem _ = ( init_vmem_sv39 ()  \<then> init_vmem_sv48 () \<then> init_vmem_sv57 () )\<close>
 
 
 \<comment> \<open>\<open>val execute : ast -> M Retired\<close>\<close>

--- a/prover_snapshots/isabelle/RV64/Riscv_lemmas.thy
+++ b/prover_snapshots/isabelle/RV64/Riscv_lemmas.thy
@@ -7,7 +7,7 @@ begin
 
 abbreviation liftS ("\<lbrakk>_\<rbrakk>\<^sub>S") where "liftS \<equiv> liftState (get_regval, set_regval)"
 
-lemmas register_defs = get_regval_def set_regval_def satp_ref_def tlb48_ref_def tlb39_ref_def
+lemmas register_defs = get_regval_def set_regval_def satp_ref_def tlb57_ref_def tlb48_ref_def tlb39_ref_def
   htif_payload_writes_ref_def htif_cmd_write_ref_def htif_exit_code_ref_def htif_done_ref_def
   htif_tohost_ref_def mtimecmp_ref_def fcsr_ref_def f31_ref_def f30_ref_def f29_ref_def f28_ref_def
   f27_ref_def f26_ref_def f25_ref_def f24_ref_def f23_ref_def f22_ref_def f21_ref_def f20_ref_def
@@ -143,6 +143,14 @@ lemma liftS_read_reg_satp[liftState_simp]:
 
 lemma liftS_write_reg_satp[liftState_simp]:
   "\<lbrakk>write_reg satp_ref v\<rbrakk>\<^sub>S = write_regS satp_ref v"
+  by (intro liftState_write_reg) (auto simp: register_defs)
+
+lemma liftS_read_reg_tlb57[liftState_simp]:
+  "\<lbrakk>read_reg tlb57_ref\<rbrakk>\<^sub>S = read_regS tlb57_ref"
+  by (intro liftState_read_reg) (auto simp: register_defs)
+
+lemma liftS_write_reg_tlb57[liftState_simp]:
+  "\<lbrakk>write_reg tlb57_ref v\<rbrakk>\<^sub>S = write_regS tlb57_ref v"
   by (intro liftState_write_reg) (auto simp: register_defs)
 
 lemma liftS_read_reg_tlb48[liftState_simp]:


### PR DESCRIPTION
This PR resolve the issue 296 open on Aug 22, 2023

### Issue

Sail allow to have only write permission on a pmp region, which is according to specs is reserved.

### Reason of issue

When pmpCheckRWX function is called to check the permission, write permission is granted only by checking the write permission bit, which should not be the case. Write permission should only be granted if there is also a Read permission.

### Solution

pmpCheckRWX function is update to 
```C
val pmpCheckRWX: (Pmpcfg_ent, AccessType(ext_access_type)) -> bool
function pmpCheckRWX(ent, acc) = {
  match acc {
    Read(_)      => ent.R() == 0b1,
    Write(_)     => ent.W() == 0b1 & ent.R() != 0b0, /* R = 0 and W = 1 is reserved */
    ReadWrite(_) => ent.R() == 0b1 & ent.W() == 0b1,
    Execute()    => ent.X() == 0b1
  }
}
```